### PR TITLE
Add a Configuration page to the documentation

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1,0 +1,100 @@
+This page details some of the options available for configuring your `esgpull` installation.
+
+### Configuration
+
+On invocation, `$ esgpull config` will show the base configurations in the terminal.
+
+```shell
+$ esgpull config
+
+──────────────────────────────────────────────────────────────────────────────────────────────────────────────────── /home/me/.esgpull/config.toml ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[paths]
+auth = "/home/me/.esgpull/auth"
+data = "/home/me/.esgpull/data"
+db = "/home/me/.esgpull/db"
+log = "/home/me/.esgpull/log"
+tmp = "/home/me/.esgpull/tmp"
+
+[credentials]
+filename = "credentials.toml"
+
+[cli]
+page_size = 20
+
+[db]
+filename = "esgpull.db"
+
+[download]
+chunk_size = 67108864
+http_timeout = 20
+max_concurrent = 5
+
+[api]
+index_node = "esgf-node.ipsl.upmc.fr"
+http_timeout = 20
+max_concurrent = 5
+page_limit = 50
+
+[api.default_options]
+distrib = "false"
+latest = "true"
+replica = "none"
+retracted = "false"
+```
+
+To modify a config item from the command line, the dot-separated path to that item must
+be provided as the first argument along with the new value that item should get as the second argument:
+
+```shell
+$ esgpull config api.index_node esgf-data.dkrz.de
+```
+```shell
+[api]
+index_node = "esgf-data.dkrz.de"
+
+Previous value: esgf-node.ipsl.upmc.fr
+```
+
+On first call, this will generate a ``config.toml`` file in the ``~/.esgpull`` directory with the
+new values modified.
+
+If a user wishes to simply generate the ``config.toml`` file without modifying any values, they
+simply must run the following:
+
+[//]: # (FIXME: This command will fail if run after modifying a config item, as the ``config.toml`` file exists.)
+
+```shell
+$ esgpull config --generate 
+```
+```shell
+
+{ ... Default configuration output ... }
+
+👍 Config generated at /home/me/.esgpull/config.toml
+```
+
+## Login
+
+In order to download data from ESGF, you will need to provide a valid login and password.
+This can be provided from the command line by running the following:
+
+```shell
+$ egsdpull login
+```
+```shell
+No credentials found.
+  [0] esg-dn1.nsc.liu.se
+  [1] esgf-data.dkrz.de
+  [2] ceda.ac.uk
+  [3] esgf-node.ipsl.upmc.fr
+  [4] esgf-node.llnl.gov
+  [5] esgf.nci.org.au
+Select a provider: 0
+User: MyESGFusername 
+Password: <hidden>
+Certificates are missing.
+👍 Renewed successfully
+```
+
+The credentials will then be saved under the ``~/.esgpull/auth`` directory, within 
+``credentials.toml``, which can then be used for future sessions.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -75,11 +75,12 @@ $ esgpull config --generate
 
 ## Login
 
-In order to download data from ESGF, you will need to provide a valid login and password.
+Although most data on ESGF can be downloaded without authentication, some datasets require a valid OpenID login and password.
+The ESGF OpenID authentication system is described on the [ESGF user documentation](http://www.esgf.io/esgf-user-support/user_guide.html).
 This can be provided from the command line by running the following:
 
 ```shell
-$ egsdpull login
+$ esgpull login
 ```
 ```shell
 No credentials found.

--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -11,8 +11,8 @@ With `esgpull`, downloading files is done after a few steps gradually altering t
 
 To make things easier to explain, we will use the following example query in this document:
 
-```sh
-esgpull search project:CMIP6 experiment_id:historical institution_id:IPSL variable_id:tas table_id:Amon member_id:r1i1p1f1 --distrib true --show
+```shell
+$ esgpull search project:CMIP6 experiment_id:historical institution_id:IPSL variable_id:tas table_id:Amon member_id:r1i1p1f1 --distrib true --show
 ```
 ![esgpull download](images/download_1.svg)
 
@@ -25,8 +25,8 @@ Our query, named `<7fd1f2>`, corresponds to the following 15 datasets:
 The first necessary step is to add `<7fd1f2>` to the database.
 Simply replace `search` with `add` and remove any flags specific to the search command, in our case we need to remove `--show`.
 
-```sh
-esgpull add project:CMIP6 experiment_id:historical institution_id:IPSL variable_id:tas table_id:Amon member_id:r1i1p1f1 --distrib true
+```shell
+$ esgpull add project:CMIP6 experiment_id:historical institution_id:IPSL variable_id:tas table_id:Amon member_id:r1i1p1f1 --distrib true
 ```
 ![esgpull download](images/download_3.svg)
 
@@ -47,8 +47,8 @@ There are 2 ways to track a query:
 - use the `track` command with the query id as an argument,
 - use the `--track` flag on the `add` command to have it tracked directly.
 
-```sh
-esgpull track 7fd1f2
+```shell
+$ esgpull track 7fd1f2
 ```
 ![esgpull download](images/download_4.svg)
 
@@ -61,8 +61,8 @@ Updating a query will send requests to the ESGF search api to fetch metadata for
 
 For those familiar with package managers such as `apt`, the `update` command should feel familiar with how those require update *lists* to fetch latest versions of packages before actually downloading (and installing in this case).
 
-```sh
-esgpull update 7fd1f2
+```shell
+$ esgpull update 7fd1f2
 ```
 ![esgpull download](images/download_5.svg)
 
@@ -77,8 +77,8 @@ esgpull update 7fd1f2
 
 All that remains after these steps is to download the files:
 
-```sh
-esgpull download
+```shell
+$ esgpull download
 ```
 ![esgpull download](images/download_6.svg)
 
@@ -96,8 +96,8 @@ For each failed download, their status will be set to **error**.
 
 Those can be put back to the download queue, by using the `retry` command.
 
-```sh
-esgpull retry --help
+```shell
+$ esgpull retry --help
 ```
 ```{.sh .markdown .result}
 Usage: esgpull retry [OPTIONS] [[new|queued|starting|started|pausing|paused|er

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -67,7 +67,7 @@ It handles scanning, downloading and updating **datasets**, **files** and *queri
 
 ## Setup
 
-Run `pip install esgpull` to install the latest release and its dependencies.
+Run `$ pip install esgpull` to install the latest release and its dependencies.
 
 Have a look at the [Installation page](installation) for more ways to install.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -1,48 +1,10 @@
-This document covers a few ways to install `esgpull`, a necessary first step into being able search and download ESGF datasets.
+This document covers a few ways to install `esgpull`, a necessary first step into being able to search and download ESGF datasets.
 
 ## Python version
 
 `esgpull` only supports python 3.10 and newer.
 
 !!! note "Supporting lower python versions could be done with future releases, do not hesitate to ask for it."
-
-
-## Setup
-
-Installing `esgpull` is the first step to using it, but not the only one.
-
-??? warning "Once you have installed the `esgpull` package, make sure to read this section."
-
-    Only a few `esgpull` commands work out of the box, namely `search` and `convert`.
-
-    To use the full set of functionalities, you will need to setup a local install with:
-
-    ```sh
-    esgpull self install
-    ```
-
-    ## Why do I need to install twice ?
-
-    The reason is that `esgpull` is prevented from writing anything on disk until installed.
-
-    Installing `esgpull` equates choosing a directory in which it is allowed to write anything it needs to run properly. It also creates all the required files/directories in that directory and fetches some metadata from ESGF that is required to run properly.
-
-    ## Multiple installs
-
-    It is possible to have multiple installs, which allows using multiple configurations on the same machine.
-
-    Installing in a directory which is an existing `esgpull` install is possible and intended. It allows sharing a single configuration across multiple users.
-
-    ## Deleting an install
-
-    To delete an `esgpull` install, it is required that this install is active.
-
-    Deleting does not `rm` any file, it only removes the option to use this install.
-
-    ```sh
-    esgpull self choose <path/to/install>
-    esgpull self delete
-    ```
 
 
 ## Installing with conda / mamba
@@ -90,3 +52,45 @@ And then install with `pip`:
 cd esg-pull
 python -m pip install .
 ```
+
+
+## Setup
+
+Installing `esgpull` is the first step to using it, but not the only one.
+
+??? warning "Once you have installed the `esgpull` package, make sure to read this section."
+
+    Only a few `esgpull` commands work out of the box, namely `search` and `convert`.
+
+    To use the full set of functionalities, you will need to setup a local install with:
+
+    ```sh
+    esgpull self install
+    ```
+
+    ## Why do I need to install twice ?
+
+    The reason is that `esgpull` is prevented from writing anything on disk until installed.
+
+    Installing `esgpull` equates choosing a directory in which it is allowed to write anything it needs to run properly. It also creates all the required files/directories in that directory and fetches some metadata from ESGF that is required to run properly.
+
+    ## Multiple installs
+
+    It is possible to have multiple installs, which allows using multiple configurations on the same machine.
+
+    Installing in a directory which is an existing `esgpull` install is possible and intended. It allows sharing a single configuration across multiple users.
+
+    ## Deleting an install
+
+    To delete an `esgpull` install, it is required that this install is active.
+
+    Deleting does not `rm` any file, it only removes the option to use this install.
+
+    ```sh
+    esgpull self choose <path/to/install>
+    esgpull self delete
+    ```
+
+## Configuration
+
+`esgpull` is highly configurable, and it is recommended to take a look at the [configuration](configuration.md) page to learn more about it.

--- a/docs/docs/quickstart.md
+++ b/docs/docs/quickstart.md
@@ -9,13 +9,13 @@ For a detailed explanation of the `search` command, read the [data discovery pag
 
 ### Search/add workflow example
 
-```sh
-esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon
-esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon --show
-esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon --detail 0
-esgpull add project:CMIP6 member_id:r1i1p1f1 frequency:mon --tag cmip6_monthly
-esgpull add --require cmip6_monthly variable_id:tas experiment_id:ssp245 --track
-esgpull add --require 2ddfa0 variable_id:tas experiment_id:ssp585 --track
+```shell
+$ esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon
+$ esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon --show
+$ esgpull search project:CMIP6 variable_id:tas experiment_id:'ssp*' member_id:r1i1p1f1 frequency:mon --detail 0
+$ esgpull add project:CMIP6 member_id:r1i1p1f1 frequency:mon --tag cmip6_monthly
+$ esgpull add --require cmip6_monthly variable_id:tas experiment_id:ssp245 --track
+$ esgpull add --require 2ddfa0 variable_id:tas experiment_id:ssp585 --track
 ```
 
 ## Converting synda selection files
@@ -51,8 +51,8 @@ variable[Omon]=fgco2 mlotst hfds o2
 
 Running the `convert` command with `--graph` will print the graph of queries the way it would appear after being added to the current install:
 
-```sh title="Convert example"
-esgpull convert example_cmip5.txt example_cmip6.txt --graph
+```shell title="Convert example"
+$ esgpull convert example_cmip5.txt example_cmip6.txt --graph
 ```
 ![esgpull convert](images/quickstart_1.svg)
 
@@ -64,25 +64,25 @@ Since the root query always corresponds to a superset of the datasets return by 
 
 To add the queries obtained from converting the selection files, they must first be exported to a yaml representation with:
 
-```sh
-esgpull convert example_cmip5.txt example_cmip6.txt --out examples_converted.yaml
+```shell
+$ esgpull convert example_cmip5.txt example_cmip6.txt --out examples_converted.yaml
 ```
 
 Adding them is done through the `add` command, under the parameter `--query-file`:
 
-```sh
-esgpull add --query-file examples_converted.yaml
-esgpull show
+```shell
+$ esgpull add --query-file examples_converted.yaml
+$ esgpull show
 ```
 
 
 ## Downloading
 
-```sh
-esgpull update <id>
-esgpull show
-esgpull download <id>
-esgpull status
+```shell
+$ esgpull update <id>
+$ esgpull show
+$ esgpull download <id>
+$ esgpull status
 ```
 
 Loop at the [download page](../download) for more information.

--- a/docs/docs/search.md
+++ b/docs/docs/search.md
@@ -5,8 +5,8 @@ Both are done through the `search` command.
 
 *Facet search* is performed with all terms using the facet syntax `<name>:<value>`, for which both name and value are matched exactly.
 
-```sh title="Search CMIP6 datasets"
-esgpull search project:CMIP6
+```shell title="Search CMIP6 datasets"
+$ esgpull search project:CMIP6
 ```
 ![esgpull search](images/search_1.svg)
 
@@ -14,15 +14,15 @@ esgpull search project:CMIP6
 
 Multiples values can be used by separating each value with a `,` comma.
 
-```sh title="Single variable search"
-esgpull search variable_id:c2h2 -0
-esgpull search variable_id:c2h6 -0
+```shell title="Single variable search"
+$ esgpull search variable_id:c2h2 -0
+$ esgpull search variable_id:c2h6 -0
 ```
 ![esgpull search](images/search_2.svg)
 ![esgpull search](images/search_3.svg)
 
 ```sh title="Combine both variables in a single search"
-esgpull search variable_id:c2h2,c2h6 -0
+$ esgpull search variable_id:c2h2,c2h6 -0
 ```
 ![esgpull search](images/search_4.svg)
 
@@ -47,7 +47,7 @@ esgpull search variable_id:c2h2,c2h6 -0
 A facet can be ignored by prepending its name with `!`. In this case, it is not possible to specify other values for this facet.
 
 ```sh title="Ignore all datasets from IPSL"
-esgpull search !institution_id:IPSL
+$ esgpull search !institution_id:IPSL
 ```
 ![esgpull search ignore](images/search_ignore.svg)
 
@@ -77,7 +77,7 @@ A *wildcard* `*` can be used in both facet (value only) and free-text search, al
 Note that on most shells, the wildcard symbol should be inside `"` quotes, to escape it from being expanded by the shell before `esgpull` receives any input.
 
 ```sh title="All initializations for areacella variable from piControl experiments"
-esgpull search "member_id:r1i*p1f1" table_id:fx variable_id:areacella experiment_id:piControl
+$ esgpull search "member_id:r1i*p1f1" table_id:fx variable_id:areacella experiment_id:piControl
 ```
 ![esgpull search](images/search_7.svg)
 
@@ -96,7 +96,7 @@ In the case of *free-text search*, the opposite is true, case is entirely insens
 <!---->
 <!-- The number of requests sent to ESGF after expanding the *subrequests* is equal to the number of *subrequests*. -->
 <!---->
-<!-- A selection file is written using either [Yaml/1.0] or [Json], Yaml is recommended for its human-readable syntax. -->
+<!-- A selection file is written using either [Yaml/1.0] or [JSON], Yaml is recommended for its human-readable syntax. -->
 <!---->
 <!-- !!! note "Syntax Rules" -->
 <!--     1. key/value pair ⇒ **facet search** term -->
@@ -305,5 +305,5 @@ In the case of *free-text search*, the opposite is true, case is entirely insens
 
 
 [Yaml/1.0]: https://yaml.org/spec/1.0
-[Json]: https://www.json.org/
+[JSON]: https://www.json.org/
 [Apache Solr]: https://fr.wikipedia.org/wiki/Apache_Solr

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: esgpull documentation
 nav:
   - esgpull: index.md
   - Installation: installation.md
+  - Configuration: configuration.md
   - Quickstart: quickstart.md
   # - Queries: queries.md
   - Data discovery: search.md


### PR DESCRIPTION
This adds a configuration page to the documentation

Related issue #18 

### Changes

* Added page showcasing how to configure your `esgpull` environment
* Reorganized the setup page to show setup commands after installation steps
* Using the `shell` directive and `$` before all commands for docs clarity
* Added a note about a potential bug that can occur when configuring environment

### Discussion

I figured it would be good to add some examples on how to enable downloads and modify configurations to the documentation. There are a few other use cases I would like to have clarified before I can add them to the docs. Will open issues accordingly.