### PR TITLE
Add disable_ssl option and CLI flag

### DIFF
--- a/docs/docs/download.md
+++ b/docs/docs/download.md
@@ -123,3 +123,11 @@ Options:
 
     * `esgpull retry starting` to send only those back to the queue
     * `esgpull retry --all` to send every download back to the queue (except `done` downloads of course)
+
+### Nodes with untrusted SSL certificates
+
+    Some data nodes may have untrusted SSL certificates.
+
+    Since esgpull uses SSL verification by default, there is a configuration option `download.disable_ssl` to bypass this behaviour.
+
+    SSL verification can also be bypassed for a single download using the `--disable-ssl` flag for the `esgpull download` command.

--- a/esgpull/cli/decorators.py
+++ b/esgpull/cli/decorators.py
@@ -85,6 +85,11 @@ class opts:
         type=int,
         default=None,
     )
+    disable_ssl: Dec = click.option(
+        "--disable-ssl",
+        is_flag=True,
+        default=False,
+    )
     dry_run: Dec = click.option(
         "--dry-run",
         "-z",

--- a/esgpull/cli/download.py
+++ b/esgpull/cli/download.py
@@ -18,12 +18,14 @@ from esgpull.utils import format_size
 @click.command()
 @args.query_id
 @opts.tag
+@opts.disable_ssl
 @opts.quiet
 @opts.record
 @opts.verbosity
 def download(
     query_id: str | None,
     tag: str | None,
+    disable_ssl: bool,
     quiet: bool,
     record: bool,
     verbosity: Verbosity,
@@ -32,6 +34,8 @@ def download(
     Asynchronously download files linked to queries
     """
     esg = init_esgpull(verbosity, record=record)
+    if disable_ssl:
+        esg.config.download.disable_ssl = True
     with esg.ui.logging("download", onraise=Abort):
         if not valid_name_tag(esg.graph, esg.ui, query_id, tag):
             esg.ui.raise_maybe_record(Exit(1))

--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -95,6 +95,7 @@ class Download:
     chunk_size: int = 1 << 26  # 64 MiB
     http_timeout: int = 20
     max_concurrent: int = 5
+    disable_ssl: bool = False
 
 
 @define


### PR DESCRIPTION
Since SSL verification prevents downloading from data nodes with untrusted certificates, this patch allows disabling it either globally or for a single download command.