### PR TITLE
Improve update command

### DIFF
--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -10,7 +10,7 @@ from esgpull.cli.utils import get_queries, init_esgpull, valid_name_tag
 from esgpull.context import HintsDict, ResultSearch
 from esgpull.exceptions import UnsetOptionsError
 from esgpull.models import File, FileStatus, Query
-from esgpull.tui import Verbosity
+from esgpull.tui import Verbosity, logger
 from esgpull.utils import format_size
 
 
@@ -168,6 +168,13 @@ def update(
                 for file in new_files:
                     file_db = esg.db.get(File, file.sha)
                     if file_db is None:
+                        if esg.db.has_file_id(file):
+                            logger.error(
+                                "File id already exists in database, "
+                                "there might be an error with its checksum"
+                                f"\n{file}"
+                            )
+                            continue
                         file.status = FileStatus.Queued
                         file_db = esg.db.merge(file)
                     elif has_legacy and legacy in file_db.queries:

--- a/esgpull/database.py
+++ b/esgpull/database.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-from typing import Iterator, Sequence, TypeVar
+from typing import TypeVar
 
 import alembic.command
 import sqlalchemy as sa
@@ -133,6 +134,9 @@ class Database:
 
     def __contains__(self, item: Table) -> bool:
         return self.scalars(sql.count(item))[0] > 0
+
+    def has_file_id(self, file: File) -> bool:
+        return len(self.scalars(sql.file.with_file_id(file.file_id))) == 1
 
     def merge(self, item: Table, commit: bool = False) -> Table:
         with self.safe:

--- a/esgpull/models/sql.py
+++ b/esgpull/models/sql.py
@@ -114,6 +114,10 @@ class file:
         return sa.select(File).where(File.status.in_(status))
 
     @staticmethod
+    def with_file_id(file_id: str) -> sa.Select[tuple[str]]:
+        return sa.select(File.sha).where(File.file_id == file_id).limit(1)
+
+    @staticmethod
     def total_size_with_status(
         *status: FileStatus,
         query_sha: str | None = None,


### PR DESCRIPTION
This improves the update command and fixes a few bugs.

Resolves https://github.com/ESGF/esgf-download/issues/5
Resolves https://github.com/ESGF/esgf-download/issues/15

### Changes

- Fix error when updating queries that return 0 file
- Skip inserting a file when its `file_id` already exists. This is caused by different checksums, most likely a publication issue.
- Print short message for each updated query with the number of associated files
- No more `print(query)` before each "update?" prompt, add a `show` option to that prompt