### PR TITLE
Add missing checksum validation, improve fs.py

### DIFF
--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -97,6 +97,7 @@ class Download:
     http_timeout: int = 20
     max_concurrent: int = 5
     disable_ssl: bool = False
+    disable_checksum: bool = False
 
 
 @define

--- a/esgpull/fs.py
+++ b/esgpull/fs.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterator
 from dataclasses import InitVar, dataclass, field
+from enum import Enum, auto
 from pathlib import Path
 from shutil import copyfile
 
@@ -10,7 +12,53 @@ from aiofiles.threadpool.binary import AsyncBufferedIOBase
 
 from esgpull.config import Config
 from esgpull.models import File
+from esgpull.result import Err, Ok, Result
 from esgpull.tui import logger
+
+
+class FileCheck(Enum):
+    Missing = auto()  # not in any known paths
+    Part = auto()  # {file.sha}.part exists
+    BadSize = auto()  # {file.sha}.done exists AND has wrong size
+    BadChecksum = auto()  # {file.sha}.done exists AND has wrong size
+    Done = auto()  # {file.sha}.done exists AND is ready to be moved
+    Ok = auto()  # file is in drs with everything ok
+
+    def as_err(self, file: File) -> Exception:
+        err_cls = type(str(self), (Exception,), {})
+        return err_cls(file)
+
+
+@dataclass
+class Digest:
+    file: InitVar[File]
+    alg: hashlib._Hash = field(init=False)
+
+    def __post_init__(self, file: File) -> None:
+        match file.checksum_type:
+            case "SHA256":
+                self.alg = hashlib.sha256()
+            case _:
+                raise NotImplementedError
+
+    @classmethod
+    def from_path(cls, file: File, path: Path) -> Digest:
+        block_size = path.stat().st_blksize
+        digest = cls(file)
+        with path.open("rb") as f:
+            while True:
+                block = f.read(block_size)
+                if block == b"":
+                    break
+                else:
+                    digest.update(block)
+        return digest
+
+    def update(self, chunk: bytes) -> None:
+        self.alg.update(chunk)
+
+    def hexdigest(self) -> str:
+        return self.alg.hexdigest()
 
 
 @dataclass
@@ -20,6 +68,7 @@ class Filesystem:
     db: Path
     log: Path
     tmp: Path
+    disable_checksum: bool = False
     install: InitVar[bool] = True
 
     @staticmethod
@@ -30,6 +79,7 @@ class Filesystem:
             db=config.paths.db,
             log=config.paths.log,
             tmp=config.paths.tmp,
+            disable_checksum=config.download.disable_checksum,
             install=install,
         )
 
@@ -41,21 +91,20 @@ class Filesystem:
             self.log.mkdir(parents=True, exist_ok=True)
             self.tmp.mkdir(parents=True, exist_ok=True)
 
-    def path_of(self, file: File) -> Path:
-        return self.data / file.local_path / file.filename
-
-    def tmp_path_of(self, file: File) -> Path:
-        return self.tmp / f"{file.sha}.part"
+    def __getitem__(self, file: File) -> FilePath:
+        if not isinstance(file, File):
+            raise TypeError(file)
+        return FilePath(
+            drs=self.data / file.local_path / file.filename,
+            tmp=self.tmp / f"{file.sha}.part",
+        )
 
     def glob_netcdf(self) -> Iterator[Path]:
         for path in self.data.glob("**/*.nc"):
             yield path.relative_to(self.data)
 
     def open(self, file: File) -> FileObject:
-        return FileObject(
-            self.tmp_path_of(file),
-            self.path_of(file),
-        )
+        return FileObject(self[file])
 
     def isempty(self, path: Path) -> bool:
         if next(path.iterdir(), None) is None:
@@ -73,9 +122,26 @@ class Filesystem:
             else:
                 return
 
+    def move_to_drs(self, file: File) -> None:
+        path = self[file]
+        path.drs.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            path.done.rename(path.drs)
+        except OSError as err:
+            logger.error(err)
+            copyfile(path.done, path.drs)
+            msg = """
+File rename error, shutil.copyfile was used instead.
+For large files, download times might be impacted.
+To address this issue, you may consider setting your `tmp` directory to the same filesystem as your `data` directory:
+
+$ esgpull config path.tmp <some/path/on/data/filesystem>
+            """.strip()
+            logger.error(msg)
+
     def delete(self, *files: File) -> None:
         for file in files:
-            path = self.path_of(file)
+            path = self[file].drs
             if not path.is_file():
                 continue
             path.unlink()
@@ -84,36 +150,104 @@ class Filesystem:
                 subpath.rmdir()
                 logger.info(f"Deleted empty folder {subpath}")
 
+    def compute_checksum(
+        self,
+        file: File,
+        path: Path,
+        disable_checksum: bool | None = None,
+    ) -> str:
+        if disable_checksum is None:
+            disable_checksum = self.disable_checksum
+        if disable_checksum:
+            return file.checksum
+        else:
+            return Digest.from_path(file, path).hexdigest()
+
+    def check_impl(
+        self,
+        file: File,
+        path: Path,
+        digest: Digest | None = None,
+    ) -> FileCheck:
+        if path.stat().st_size != file.size:
+            return FileCheck.BadSize
+        if digest is None:
+            checksum = self.compute_checksum(file, path)
+        else:
+            checksum = digest.hexdigest()
+        if checksum == file.checksum:
+            return FileCheck.Ok
+        else:
+            return FileCheck.BadChecksum
+
+    def check(
+        self,
+        file: File,
+        digest: Digest | None = None,
+    ) -> FileCheck:
+        path = self[file]
+        if path.drs.is_file():
+            return self.check_impl(file, path.drs, digest)
+        elif path.done.is_file():
+            match self.check_impl(file, path.done, digest):
+                case FileCheck.Ok:
+                    return FileCheck.Done
+                case check:
+                    return check
+        elif path.tmp.is_file():
+            match self.check_impl(file, path.tmp, digest):
+                case FileCheck.BadSize:
+                    return FileCheck.Part
+                case _:
+                    raise ValueError()
+        else:
+            return FileCheck.Missing
+
+    def finalize(
+        self,
+        file: File,
+        digest: Digest | None = None,
+    ) -> Result[FileCheck]:
+        match self.check(file, digest=digest):
+            case FileCheck.Ok:
+                return Ok(FileCheck.Ok)
+            case FileCheck.Done:
+                self.move_to_drs(file)
+                return Ok(FileCheck.Ok)
+            case check:
+                return Err(check, check.as_err(file))
+
+
+@dataclass
+class FilePath:
+    drs: Path
+    tmp: Path
+
+    @property
+    def done(self) -> Path:
+        return self.tmp.with_suffix(".done")
+
+    def __str__(self) -> str:
+        return str(self.drs)
+
 
 @dataclass
 class FileObject:
-    tmp_path: Path
-    final_path: Path
-    finished: bool = False
+    path: FilePath
     buffer: AsyncBufferedIOBase = field(init=False)
 
     async def __aenter__(self) -> FileObject:
-        self.buffer = await aiofiles.open(self.tmp_path, "wb")
+        self.buffer = await aiofiles.open(self.path.tmp, "wb")
         return self
-
-    async def write(self, chunk: bytes) -> None:
-        await self.buffer.write(chunk)
 
     async def __aexit__(self, exc_type, exc_value, exc_traceback) -> None:
         if not self.buffer.closed:
             await self.buffer.close()
-        if self.finished:
-            self.final_path.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                self.tmp_path.rename(self.final_path)
-            except OSError as err:
-                logger.error(err)
-                copyfile(self.tmp_path, self.final_path)
-                msg = """
-File rename error, shutil.copyfile was used instead.
-For large files, download times might be impacted.
-To address this issue, you may consider setting your `tmp` directory to the same filesystem as your `data` directory:
 
-$ esgpull config path.tmp <some/path/on/data/filesystem>
-                """.strip()
-                logger.warn(msg)
+    async def write(self, chunk: bytes) -> None:
+        await self.buffer.write(chunk)
+
+    async def to_done(self) -> None:
+        if not self.buffer.closed:
+            await self.buffer.close()
+        self.path.tmp.rename(self.path.done)

--- a/esgpull/tui.py
+++ b/esgpull/tui.py
@@ -62,12 +62,21 @@ class Verbosity(IntEnum):
         return Text(self.name.upper(), style=f"logging.level.{self.name}")
 
 
+class DummyConsole:
+    def print(self, msg: str) -> None:
+        pass
+
+
 class DummyLive:
-    def __enter__(self):
-        ...
+    def __enter__(self) -> DummyLive:
+        return self
 
     def __exit__(self, *args):
         ...
+
+    @property
+    def console(self) -> DummyConsole:
+        return DummyConsole()
 
 
 def yaml_syntax(data: Mapping[str, Any]) -> Syntax:

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -3,7 +3,13 @@ import asyncio
 import pytest
 
 from esgpull.config import Config
-from esgpull.fs import Filesystem
+from esgpull.fs import FileCheck, Filesystem
+
+
+@pytest.fixture
+def fs_no_install(root):
+    config = Config()
+    return Filesystem.from_config(config, install=False)
 
 
 @pytest.fixture
@@ -12,12 +18,7 @@ def fs(root):
     return Filesystem.from_config(config, install=True)
 
 
-@pytest.fixture
-def file_object(fs, file):
-    return fs.open(file_object)
-
-
-def test_fs(root, fs):
+def test_install(root, fs):
     assert str(fs.auth) == str(root / "auth")
     assert str(fs.data) == str(root / "data")
     assert str(fs.db) == str(root / "db")
@@ -30,18 +31,148 @@ def test_fs(root, fs):
     assert fs.tmp.is_dir()
 
 
+def test_no_install(root, fs_no_install):
+    assert str(fs_no_install.auth) == str(root / "auth")
+    assert str(fs_no_install.data) == str(root / "data")
+    assert str(fs_no_install.db) == str(root / "db")
+    assert str(fs_no_install.log) == str(root / "log")
+    assert str(fs_no_install.tmp) == str(root / "tmp")
+    assert not fs_no_install.auth.is_dir()
+    assert not fs_no_install.data.is_dir()
+    assert not fs_no_install.db.is_dir()
+    assert not fs_no_install.log.is_dir()
+    assert not fs_no_install.tmp.is_dir()
+
+
 def test_file_paths(fs, file):
     file.sha = "1234"
-    assert fs.path_of(file) == fs.data / "project/folder/file.nc"
-    assert fs.tmp_path_of(file) == fs.tmp / "1234.part"
+    path = fs[file]
+    assert path.drs == fs.data / "project/folder/file.nc"
+    assert path.tmp == fs.tmp / "1234.part"
 
 
-async def writer_steps(fs, file):
+async def write_steps(fs, file):
     async with fs.open(file) as f:
         await f.write(b"")
 
 
-def test_fs_writer(fs, file):
-    asyncio.run(writer_steps(fs, file))
+def test_write(fs, file):
+    asyncio.run(write_steps(fs, file))
     for path in fs.glob_netcdf():
         assert str(path) == "project/folder/file.nc"
+
+
+@pytest.mark.parametrize(
+    "expected_check,content,kind,size,checksum",
+    [
+        pytest.param(
+            FileCheck.Missing,
+            None,
+            None,
+            None,
+            None,
+            id="file does not exist anywhere",
+        ),
+        pytest.param(
+            FileCheck.Part,
+            "cont",
+            "tmp",
+            7,
+            None,
+            id="size not matching content (tmp)",
+        ),
+        pytest.param(
+            FileCheck.BadSize,
+            "content",
+            "done",
+            0,
+            None,
+            id="size not matching content (done)",
+        ),
+        pytest.param(
+            FileCheck.BadSize,
+            "content",
+            "drs",
+            0,
+            None,
+            id="size not matching content (drs)",
+        ),
+        pytest.param(
+            FileCheck.BadChecksum,
+            "content",
+            "tmp",
+            7,
+            "",
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+            id="checksum not matching content (tmp)",
+        ),
+        pytest.param(
+            FileCheck.BadChecksum,
+            "content",
+            "done",
+            7,
+            "0",
+            id="checksum not matching content (done)",
+        ),
+        pytest.param(
+            FileCheck.BadChecksum,
+            "content",
+            "drs",
+            7,
+            "0",
+            id="checksum not matching content (drs)",
+        ),
+        pytest.param(
+            FileCheck.Done,
+            "content",
+            "tmp",
+            7,
+            "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+            id="size and checksum match content (tmp)",
+        ),
+        pytest.param(
+            FileCheck.Done,
+            "content",
+            "done",
+            7,
+            "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
+            id="size and checksum match content (done)",
+        ),
+        pytest.param(
+            FileCheck.Ok,
+            "content",
+            "drs",
+            7,
+            "ed7002b439e9ac845f22357d822bac1444730fbdb6016d3ec9432297b9ec9f73",
+            id="size and checksum match content (drs)",
+        ),
+    ],
+)
+def test_check(
+    root,
+    fs,
+    file,
+    expected_check,
+    content,
+    kind,
+    size,
+    checksum,
+):
+    if content is not None:
+        file.size = size
+        file.checksum = checksum
+        file.checksum_type = "SHA256"
+        if kind == "tmp":
+            path = fs[file].tmp
+        elif kind == "done":
+            path = fs[file].done
+        elif kind == "drs":
+            path = fs[file].drs
+            path.parent.mkdir(parents=True)
+        else:
+            path = root / kind
+        with path.open("wb") as f:
+            f.write(str(content).encode())
+    check = fs.check(file)
+    assert check == expected_check


### PR DESCRIPTION
Add `Config.download.disable_checksum` boolean option (default=False) to disable the checksum computation during download.

Add `Digest` class for hash computing:
* used in `Filesystem` methods `check()` and `finalize()` to validate checksum
* used in `DownloadCtx` and is updated for every received chunk of data

Add `FileCheck` enum to specify the status of a file on the filesystem:
* Missing: file is not found at any of the expected paths (`tmp` or `data`)
* Part: file is in `tmp/<sha>.part`, its download is not complete
* BadSize: file is either in `tmp/<sha>.done`, or in `data/<DRS>`, its **size** does not match expectations from the metadata
* BadChecksum: file is either in `tmp/<sha>.done`, or in `data/<DRS>`, its **checksum** does not match expectations from the metadata
* Done: file is in `tmp/<sha>.done` and has valid size and checksum
* Ok: file is in `data/<DRS>` and has valid size and checksum

### Other changes

* Improved output during download: - add file.sha and data_node to progress output - print & log each successful download
* Fix an issue with file staying `started` but not downloaded: - `Processor.should_download()` gives `False` but the file was added to db already with `starting` status
* Moving a completed file from `tmp` to its DRS path is now done inside `Filesystem.finalize` instead of inside `FileObject.__aexit__`
* Add test cases for `Filesystem.check()`
* Mark test that downloads a file from IPSL data node as `xfail`