### PR TITLE
Add default query

### DIFF
--- a/esgpull/cli/add.py
+++ b/esgpull/cli/add.py
@@ -21,20 +21,22 @@ from esgpull.tui import Verbosity
 @groups.query_def
 @opts.query_file
 @opts.track
+@opts.no_default_query
 @opts.record
 @opts.verbosity
 def add(
     facets: list[str],
-    # query options
+    ## query_def
     tags: list[str],
     require: str | None,
     distrib: str | None,
     latest: str | None,
     replica: str | None,
     retracted: str | None,
-    # since: str | None,
+    ## ungrouped
     query_file: Path | None,
     track: bool,
+    no_default_query: bool,
     record: bool,
     verbosity: Verbosity,
 ) -> None:
@@ -55,7 +57,11 @@ def add(
 
     To fetch files from ESGF and link them to a query, see the `track` and `update` commands.
     """
-    esg = init_esgpull(verbosity, record=record)
+    esg = init_esgpull(
+        verbosity,
+        record=record,
+        no_default_query=no_default_query,
+    )
     with esg.ui.logging("add", onraise=Abort):
         if query_file is not None:
             queries = serialize_queries_from_file(query_file)
@@ -77,6 +83,7 @@ def add(
                     expanded = query
                 query.track(expanded.options)
             queries = [query]
+        queries = esg.insert_default_query(*queries)
         subgraph = Graph(None)
         subgraph.add(*queries)
         esg.ui.print(subgraph)

--- a/esgpull/cli/decorators.py
+++ b/esgpull/cli/decorators.py
@@ -143,6 +143,11 @@ class opts:
         type=str,
         default=None,
     )
+    no_default_query: Dec = click.option(
+        "--no-default-query",
+        is_flag=True,
+        default=False,
+    )
     query_file: Dec = click.option(
         "--query-file",
         "-q",

--- a/esgpull/cli/search.py
+++ b/esgpull/cli/search.py
@@ -18,17 +18,17 @@ from esgpull.tui import Verbosity
 @groups.query_def
 @groups.query_date
 @groups.display
+@groups.json_yaml
+@opts.detail
+@opts.no_default_query
+@opts.show
 @opts.dry_run
 @opts.file
 @opts.facets_hints
 @opts.hints
-@groups.json_yaml
-@opts.detail
-@opts.show
 @opts.yes
 @opts.record
 @opts.verbosity
-# @opts.selection_file
 def search(
     facets: list[str],
     ## query_def
@@ -38,6 +38,7 @@ def search(
     latest: str | None,
     replica: str | None,
     retracted: str | None,
+    ## query_date
     date_from: datetime | None,
     date_to: datetime | None,
     ## display
@@ -48,14 +49,14 @@ def search(
     json: bool,
     yaml: bool,
     ## ungrouped
-    show: bool,
     detail: int | None,
+    no_default_query: bool,
+    show: bool,
     dry_run: bool,
     file: bool,
     facets_hints: bool,
     hints: list[str] | None,
     yes: bool,
-    # selection_file: str | None,
     record: bool,
     verbosity: Verbosity,
 ) -> None:
@@ -64,7 +65,12 @@ def search(
 
     More info
     """
-    esg = init_esgpull(verbosity, safe=False, record=record)
+    esg = init_esgpull(
+        verbosity,
+        safe=False,
+        record=record,
+        no_default_query=no_default_query,
+    )
     with esg.ui.logging("search", onraise=Abort):
         query = parse_query(
             facets=facets,
@@ -77,6 +83,7 @@ def search(
         )
         query.compute_sha()
         esg.graph.resolve_require(query)
+        query = esg.insert_default_query(query)[0]
         if show:
             if json:
                 esg.ui.print(query.asdict(), json=True)

--- a/esgpull/cli/utils.py
+++ b/esgpull/cli/utils.py
@@ -1,8 +1,9 @@
 import sys
 from collections import OrderedDict
+from collections.abc import MutableMapping, Sequence
 from enum import Enum
 from pathlib import Path
-from typing import Any, Literal, MutableMapping, Sequence
+from typing import Any, Literal
 
 import click
 import yaml
@@ -29,6 +30,7 @@ def init_esgpull(
     safe: bool = True,
     record: bool = False,
     load_db: bool = True,
+    no_default_query: bool = False,
 ) -> Esgpull:
     TempUI.verbosity = Verbosity.Errors
     with TempUI.logging():
@@ -38,6 +40,8 @@ def init_esgpull(
             record=record,
             load_db=load_db,
         )
+        if no_default_query:
+            esg.config.api.default_query_id = ""
         if record:
             esg.ui.print(get_command())
     return esg

--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -125,6 +125,7 @@ class API:
     max_concurrent: int = 5
     page_limit: int = 50
     default_options: DefaultOptions = Factory(DefaultOptions)
+    default_query_id: str = ""
 
 
 def fix_rename_search_api(doc: TOMLDocument) -> TOMLDocument:

--- a/esgpull/exceptions.py
+++ b/esgpull/exceptions.py
@@ -112,6 +112,10 @@ class VirtualConfigError(EsgpullException):
 class InstallException(EsgpullException): ...
 
 
+class UnknownDefaultQueryID(EsgpullException):
+    msg = "{}"
+
+
 class UntrackableQuery(EsgpullException):
     msg = """
     {} cannot be tracked, it has unset options.

--- a/esgpull/models/selection.py
+++ b/esgpull/models/selection.py
@@ -199,6 +199,7 @@ BaseFacets = [
     "member_id",
     "cmor_table",
     "grid_label",
+    "nominal_resolution",
 ]
 
 

--- a/tests/test_esgpull.py
+++ b/tests/test_esgpull.py
@@ -1,0 +1,42 @@
+import pytest
+
+from esgpull import Esgpull
+from esgpull.models import Query
+
+
+def test_insert_default_query(root):
+    esg = Esgpull(root, install=True)
+    default_query = Query(selection=dict(project="IPSL"))
+    default_query.compute_sha()
+    esg.graph.add(default_query)
+    esg.config.api.default_query_id = default_query.sha
+    queries = [
+        Query(selection=dict(variable="tas")),
+        Query(selection=dict(institution_id="toto")),
+        Query(selection=dict(time_frequency="day")),
+        Query(selection=dict(variable="pr")),
+    ]
+    for q in queries:
+        q.compute_sha()
+    queries.append(
+        Query(require=queries[-1].sha, selection=dict(member_id="r1i1p1f1"))
+    )
+    queries[-1].compute_sha()
+    queries.append(
+        Query(require=queries[-1].sha, selection=dict(table_id="Amon"))
+    )
+    queries[-1].compute_sha()
+    new_queries = esg.insert_default_query(*queries)
+    esg.graph.add(*new_queries)
+    assert len(esg.graph.queries) == 7
+    for query in queries:
+        with pytest.raises(KeyError):
+            esg.graph.get(query.sha)
+    for i, query in enumerate(new_queries):
+        assert esg.graph.get(query.sha) == query
+        if i in range(4):
+            assert query.require == default_query.sha
+        elif i == 4:
+            assert query.require == new_queries[3].sha
+        elif i == 5:
+            assert query.require == new_queries[4].sha


### PR DESCRIPTION
### Module changes

Add `Config.api.default_query_id` string option (default=""). This enables using a pre-existing query as a parent applied to all queries having no require.

Add `Esgpull.insert_default_query` method to insert the default query specified in the config to queries having no require, and update children queries `require` value accordingly.

### CLI changes

For both `add` and `search` commands, the default query specified in the config is inserted as a `require` to any "require-less" query provided from the command's arguments.

Add `--no-default-query` option to `add` and `search` commands, to disable the default query mechanism. This is effectively useless if no default query is specified in the config.