### PR TITLE
Download show filename

### DIFF
--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Container, Iterator, Mapping
+from collections.abc import Iterator, Mapping
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, cast
 
 import tomlkit
-from attrs import Factory, define, field
+from attrs import Factory, define, field, fields
+from attrs import has as attrs_has
 from cattrs import Converter
 from cattrs.gen import make_dict_unstructure_fn, override
 from tomlkit import TOMLDocument
@@ -299,15 +300,29 @@ class Config:
             doc.setdefault(part, {})
             doc = doc[part]
             obj = getattr(obj, part)
+        value_type = getattr(fields(type(obj)), last).type
         old_value = getattr(obj, last)
-        if isinstance(old_value, str):
-            ...
-        elif isinstance(old_value, Container):
+        if attrs_has(value_type):
             raise KeyError(key)
-        try:
-            value = int(value)
-        except ValueError:
+        elif value_type is str:
             ...
+        elif value_type is int:
+            try:
+                value = value_type(value)
+            except Exception:
+                ...
+        elif value_type is bool:
+            if isinstance(value, bool):
+                ...
+            elif isinstance(value, str):
+                if value.lower() in ["on", "true"]:
+                    value = True
+                elif value.lower() in ["off", "false"]:
+                    value = False
+                else:
+                    raise ValueError(value)
+            else:
+                raise TypeError(value)
         setattr(obj, last, value)
         doc[last] = value
         return old_value

--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -98,6 +98,7 @@ class Download:
     max_concurrent: int = 5
     disable_ssl: bool = False
     disable_checksum: bool = False
+    show_filename: bool = False
 
 
 @define

--- a/esgpull/esgpull.py
+++ b/esgpull/esgpull.py
@@ -13,6 +13,7 @@ from rich.progress import (
     DownloadColumn,
     MofNCompleteColumn,
     Progress,
+    ProgressColumn,
     SpinnerColumn,
     TaskID,
     TextColumn,
@@ -369,7 +370,7 @@ class Esgpull:
             MofNCompleteColumn(),
             TimeRemainingColumn(compact=True, elapsed_when_finished=True),
         )
-        file_columns = [
+        file_columns: list[str | ProgressColumn] = [
             TextColumn("[cyan][{task.id}] [b blue]{task.fields[sha]}"),
             "[progress.percentage]{task.percentage:>3.0f}%",
             BarColumn(),

--- a/esgpull/esgpull.py
+++ b/esgpull/esgpull.py
@@ -337,7 +337,10 @@ class Esgpull:
                                 data_node = (
                                     f"[blue]{task.fields['data_node']}[/]"
                                 )
-                                msg = " · ".join([sha, size, speed, data_node])
+                                parts = [sha, size, speed, data_node]
+                                if self.config.download.show_filename:
+                                    parts.append(task.fields["filename"])
+                                msg = " · ".join(parts)
                                 logger.info(msg)
                                 live.console.print(msg)
                                 yield result
@@ -366,7 +369,7 @@ class Esgpull:
             MofNCompleteColumn(),
             TimeRemainingColumn(compact=True, elapsed_when_finished=True),
         )
-        file_progress = self.ui.make_progress(
+        file_columns = [
             TextColumn("[cyan][{task.id}] [b blue]{task.fields[sha]}"),
             "[progress.percentage]{task.percentage:>3.0f}%",
             BarColumn(),
@@ -376,6 +379,16 @@ class Esgpull:
             TransferSpeedColumn(),
             "·",
             TextColumn("[blue]{task.fields[data_node]}"),
+        ]
+        if self.config.download.show_filename:
+            file_columns.extend(
+                [
+                    "·",
+                    TextColumn("{task.fields[filename]}"),
+                ]
+            )
+        file_progress = self.ui.make_progress(
+            *file_columns,
             transient=True,
         )
         file_task_shas = {}
@@ -387,6 +400,7 @@ class Esgpull:
                 visible=False,
                 start=False,
                 sha=short_sha(file.sha),
+                filename=file.filename,
                 data_node=file.data_node,
             )
             callback = partial(file_progress.start_task, task_id)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,3 +39,19 @@ def test_deprecated_search_api_error(root, config_path):
         raise
     finally:
         config_path.unlink()
+
+
+def test_update_config(root, config_path):
+    root.mkdir(parents=True)
+    with open(config_path, "w") as f:
+        tomlkit.dump({}, f)
+    config = Config.load(root)
+    config.download.disable_ssl = True
+    config.update_item("download.disable_ssl", "false")
+    assert config.download.disable_ssl is False
+    config.update_item("download.disable_ssl", "true")
+    assert config.download.disable_ssl is True
+    config.update_item("download.disable_ssl", False)
+    assert config.download.disable_ssl is False
+    with pytest.raises(ValueError):
+        config.update_item("download.disable_ssl", "bad_value")


### PR DESCRIPTION
Resolves https://github.com/ESGF/esgf-download/issues/33

Fixes an issue with boolean config entries: setting it to either `true` or `false` from the CLI would make them evaluate to `True` since in python, conversion of `x: str` to `bool` is the same as `len(x) > 0`, so special handling is required.