### PR TITLE
feat(cli): add datasets command (per query)

### DIFF
--- a/esgpull/cli/__init__.py
+++ b/esgpull/cli/__init__.py
@@ -7,6 +7,7 @@ from esgpull import __version__
 from esgpull.cli.add import add
 from esgpull.cli.config import config
 from esgpull.cli.convert import convert
+from esgpull.cli.datasets import datasets
 from esgpull.cli.download import download
 from esgpull.cli.login import login
 from esgpull.cli.remove import remove
@@ -34,6 +35,7 @@ SUBCOMMANDS: list[click.Command] = [
     # autoremove,
     config,
     convert,
+    datasets,
     download,
     # facet,
     # get,

--- a/esgpull/cli/datasets.py
+++ b/esgpull/cli/datasets.py
@@ -7,7 +7,7 @@ from rich.box import MINIMAL_DOUBLE_HEAD
 from rich.table import Table
 
 from esgpull.cli.decorators import args, groups, opts
-from esgpull.cli.utils import init_esgpull
+from esgpull.cli.utils import init_esgpull, valid_name_tag
 from esgpull.models import FileStatus
 from esgpull.tui import Verbosity
 
@@ -29,11 +29,11 @@ class DatasetCounter:
 
 
 @click.command()
-@args.query_id
+@args.query_id_required
 @groups.json_yaml
 @opts.verbosity
 def datasets(
-    query_id: str | None,
+    query_id: str,
     json: bool,
     yaml: bool,
     verbosity: Verbosity,
@@ -41,10 +41,10 @@ def datasets(
     """
     View datasets completeness per query.
     """
-    if query_id is None:
-        raise Exit(1)
     esg = init_esgpull(verbosity)
     with esg.ui.logging("datasets", onraise=Abort):
+        if not valid_name_tag(esg.graph, esg.ui, query_id, None):
+            raise Exit(1)
         query = esg.graph.get(query_id)
         datasets: defaultdict[str, DatasetCounter] = defaultdict(
             DatasetCounter

--- a/esgpull/cli/datasets.py
+++ b/esgpull/cli/datasets.py
@@ -1,0 +1,78 @@
+from collections import defaultdict
+from dataclasses import dataclass
+
+import click
+from click.exceptions import Abort, Exit
+from rich.box import MINIMAL_DOUBLE_HEAD
+from rich.table import Table
+
+from esgpull.cli.decorators import args, groups, opts
+from esgpull.cli.utils import init_esgpull
+from esgpull.models import FileStatus
+from esgpull.tui import Verbosity
+
+
+@dataclass
+class DatasetCounter:
+    done: int = 0
+    total: int = 0
+
+    def is_complete(self) -> int:
+        return self.done == self.total
+
+    def asdict(self) -> dict:
+        return {
+            "done": self.done,
+            "total": self.total,
+            "complete": self.is_complete(),
+        }
+
+
+@click.command()
+@args.query_id
+@groups.json_yaml
+@opts.verbosity
+def datasets(
+    query_id: str | None,
+    json: bool,
+    yaml: bool,
+    verbosity: Verbosity,
+):
+    """
+    View datasets completeness per query.
+    """
+    if query_id is None:
+        raise Exit(1)
+    esg = init_esgpull(verbosity)
+    with esg.ui.logging("datasets", onraise=Abort):
+        query = esg.graph.get(query_id)
+        datasets: defaultdict[str, DatasetCounter] = defaultdict(
+            DatasetCounter
+        )
+        for file in query.files:
+            datasets[file.dataset_id].total += 1
+            if file.status == FileStatus.Done:
+                datasets[file.dataset_id].done += 1
+        if json or yaml:
+            datasets_dict = {
+                dataset_id: counts.asdict()
+                for dataset_id, counts in datasets.items()
+            }
+            if json:
+                esg.ui.print(datasets_dict, json=True)
+            elif yaml:
+                esg.ui.print(datasets_dict, yaml=True)
+        else:
+            table = Table(box=MINIMAL_DOUBLE_HEAD, show_edge=False)
+            table.add_column("dataset_id", justify="right", style="bold blue")
+            table.add_column("done", justify="center")
+            table.add_column("total", justify="center")
+            table.add_column("complete", justify="center")
+            for dataset_id, counts in datasets.items():
+                table.add_row(
+                    dataset_id,
+                    str(counts.done),
+                    str(counts.total),
+                    str(counts.is_complete()),
+                )
+            esg.ui.print(table)

--- a/esgpull/cli/decorators.py
+++ b/esgpull/cli/decorators.py
@@ -59,6 +59,12 @@ class args:
         nargs=1,
         required=False,
     )
+    query_id_required: Dec = click.argument(
+        "query_id",
+        type=str,
+        nargs=1,
+        required=True,
+    )
     query_ids: Dec = click.argument(
         "query_ids",
         type=str,


### PR DESCRIPTION
## Changes

* Added `datasets` subcommand to access information about dataset completeness per query.

Using this example query:
```shell
$ esgpull show 3c953f
<3c953f>
└── distrib:       True                                      
    latest:        True                                      
    replica:       None                                      
    retracted:     False                                     
    experiment_id: historical, ssp126, ssp245, ssp370, ssp585
    project:       CMIP6                                     
    source_id:     GFDL-ESM4, MIROC-ES2L                     
    table_id:      Eday, EdayZ                               
    variable_id:   zg                                        
    variant_label: r1i1p1f1, r1i1p1f2                        
    files:         238.9 GiB / 239.4 GiB [925/934]           
```


```shell
$ esgpull datasets 3c953f
                                                                    dataset_id │ done │ total │ complete 
═══════════════════════════════════════════════════════════════════════════════╪══════╪═══════╪══════════
       CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp585.r1i1p1f2.Eday.zg.gn.v20220530 │ 286  │  286  │   True   
       CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp126.r1i1p1f2.Eday.zg.gn.v20220530 │ 286  │  286  │   True   
          CMIP6.CMIP.MIROC.MIROC-ES2L.historical.r1i1p1f2.Eday.zg.gn.v20191129 │ 165  │  165  │   True   
       CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp245.r1i1p1f2.Eday.zg.gn.v20200318 │  86  │  86   │   True   
    CMIP6.CMIP.NOAA-GFDL.GFDL-ESM4.historical.r1i1p1f1.EdayZ.zg.gr1z.v20190726 │  0   │   9   │  False   
       CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp370.r1i1p1f2.Eday.zg.gn.v20200318 │  86  │  86   │   True   
      CMIP6.CMIP.NOAA-GFDL.GFDL-ESM4.historical.r1i1p1f1.Eday.zg.gr1.v20190726 │  9   │   9   │   True   
   CMIP6.ScenarioMIP.NOAA-GFDL.GFDL-ESM4.ssp585.r1i1p1f1.Eday.zg.gr1.v20180701 │  2   │   2   │   True   
 CMIP6.ScenarioMIP.NOAA-GFDL.GFDL-ESM4.ssp585.r1i1p1f1.EdayZ.zg.gr1z.v20180701 │  5   │   5   │   True
```


```shell
$ esgpull datasets 3c953f --json
{
  "CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp585.r1i1p1f2.Eday.zg.gn.v20220530": {
    "done": 286,
    "total": 286,
    "complete": true
  },
  "CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp126.r1i1p1f2.Eday.zg.gn.v20220530": {
    "done": 286,
    "total": 286,
    "complete": true
  },
  "CMIP6.CMIP.MIROC.MIROC-ES2L.historical.r1i1p1f2.Eday.zg.gn.v20191129": {
    "done": 165,
    "total": 165,
    "complete": true
  },
  "CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp245.r1i1p1f2.Eday.zg.gn.v20200318": {
    "done": 86,
    "total": 86,
    "complete": true
  },
  "CMIP6.CMIP.NOAA-GFDL.GFDL-ESM4.historical.r1i1p1f1.EdayZ.zg.gr1z.v20190726": {
    "done": 0,
    "total": 9,
    "complete": false
  },
  "CMIP6.ScenarioMIP.MIROC.MIROC-ES2L.ssp370.r1i1p1f2.Eday.zg.gn.v20200318": {
    "done": 86,
    "total": 86,
    "complete": true
  },
  "CMIP6.CMIP.NOAA-GFDL.GFDL-ESM4.historical.r1i1p1f1.Eday.zg.gr1.v20190726": {
    "done": 9,
    "total": 9,
    "complete": true
  },
  "CMIP6.ScenarioMIP.NOAA-GFDL.GFDL-ESM4.ssp585.r1i1p1f1.Eday.zg.gr1.v20180701": {
    "done": 2,
    "total": 2,
    "complete": true
  },
  "CMIP6.ScenarioMIP.NOAA-GFDL.GFDL-ESM4.ssp585.r1i1p1f1.EdayZ.zg.gr1z.v20180701": {
    "done": 5,
    "total": 5,
    "complete": true
  }
}
```