### PR TITLE
Greatly improve database performance for `esgpull update`

### DIFF
--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -166,7 +166,10 @@ def update(
                 legacy = esg.legacy_query
                 has_legacy = legacy.state.persistent
                 with esg.db.commit_context():
-                    for file in esg.ui.track(new_files):
+                    for file in esg.ui.track(
+                        new_files,
+                        description=qf.query.rich_name,
+                    ):
                         file_db = esg.db.get(File, file.sha)
                         if file_db is None:
                             if esg.db.has_file_id(file):

--- a/esgpull/constants.py
+++ b/esgpull/constants.py
@@ -1,4 +1,5 @@
 CONFIG_FILENAME = "config.toml"
+INSTALLS_PATH_ENV = "ESGPULL_INSTALLS_PATH"
 ROOT_ENV = "ESGPULL_CURRENT"
 
 IDP = "/esgf-idp/openid/"

--- a/esgpull/install_config.py
+++ b/esgpull/install_config.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import platformdirs
 from typing_extensions import NotRequired, TypedDict
 
-from esgpull.constants import ROOT_ENV
+from esgpull.constants import INSTALLS_PATH_ENV, ROOT_ENV
 from esgpull.exceptions import AlreadyInstalledName, AlreadyInstalledPath
 
 
@@ -44,8 +44,13 @@ class _InstallConfig:
     current_idx: int | None
     installs: list[Install]
 
-    def __init__(self) -> None:
-        user_config_dir = platformdirs.user_config_path("esgpull")
+    def __init__(self, install_path: Path | None = None) -> None:
+        if install_path is not None:
+            user_config_dir = install_path
+        elif (env := os.environ.get(INSTALLS_PATH_ENV)) is not None:
+            user_config_dir = Path(env)
+        else:
+            user_config_dir = platformdirs.user_config_path("esgpull")
         self.path = user_config_dir / "installs.json"
         if self.path.is_file():
             with self.path.open() as f:

--- a/esgpull/install_config.py
+++ b/esgpull/install_config.py
@@ -44,7 +44,10 @@ class _InstallConfig:
     current_idx: int | None
     installs: list[Install]
 
-    def __init__(self, install_path: Path | None = None) -> None:
+    def __init__(self) -> None:
+        self.setup()
+
+    def setup(self, install_path: Path | None = None):
         if install_path is not None:
             user_config_dir = install_path
         elif (env := os.environ.get(INSTALLS_PATH_ENV)) is not None:

--- a/esgpull/models/selection.py
+++ b/esgpull/models/selection.py
@@ -72,6 +72,10 @@ class Selection(Base):
         setattr(cls, name, property(getter, setter))
 
     @classmethod
+    def reset(cls) -> None:
+        cls.configure(*DefaultFacets, *BaseFacets, replace=True)
+
+    @classmethod
     def configure(cls, *names: str, replace: bool = True) -> None:
         nameset = set(names) | {f"!{name}" for name in names}
         if replace:
@@ -198,4 +202,4 @@ BaseFacets = [
 ]
 
 
-Selection.configure(*DefaultFacets, *BaseFacets, replace=True)
+Selection.reset()

--- a/esgpull/models/sql.py
+++ b/esgpull/models/sql.py
@@ -256,3 +256,19 @@ class synda_file:
     @staticmethod
     def with_ids(*ids: int) -> sa.Select[tuple[SyndaFile]]:
         return sa.select(SyndaFile).where(SyndaFile.file_id.in_(ids))
+
+
+class query_file:
+    @staticmethod
+    def link(query: Query, file: File) -> sa.Insert:
+        return sa.insert(query_file_proxy).values(
+            query_sha=query.sha, file_sha=file.sha
+        )
+
+    @staticmethod
+    def unlink(query: Query, file: File) -> sa.Delete:
+        return (
+            sa.delete(query_file_proxy)
+            .where(query_file_proxy.c.query_sha == query.sha)
+            .where(query_file_proxy.c.file_sha == file.sha)
+        )

--- a/esgpull/tui.py
+++ b/esgpull/tui.py
@@ -71,8 +71,7 @@ class DummyLive:
     def __enter__(self) -> DummyLive:
         return self
 
-    def __exit__(self, *args):
-        ...
+    def __exit__(self, *args): ...
 
     @property
     def console(self) -> DummyConsole:
@@ -259,9 +258,9 @@ class UI:
         # use _console to avoid recording the progress bar
         return Live(renderables, console=_console)
 
-    def track(self, iterable: Iterable[T]) -> Iterable[T]:
+    def track(self, iterable: Iterable[T], **kwargs) -> Iterable[T]:
         # use _console to avoid recording the progress bar
-        return track(iterable, console=_console)
+        return track(iterable, console=_console, **kwargs)
 
     def make_progress(
         self,

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,27 +1,22 @@
 from time import perf_counter
 
-import pytest
 from click.testing import CliRunner
 
 from esgpull.cli.add import add
 from esgpull.cli.config import config
+from esgpull.cli.self import install
 from esgpull.cli.update import update
-from esgpull.constants import INSTALLS_PATH_ENV
-from esgpull.install_config import _InstallConfig
+from esgpull.install_config import InstallConfig
 
 
-@pytest.fixture
-def runner(tmp_path):
-    InstallConfig = _InstallConfig(tmp_path)
-    idx = InstallConfig.add(tmp_path / "esgpull")
-    InstallConfig.choose(idx=idx)
-    InstallConfig.write()
-    _runner = CliRunner(env={INSTALLS_PATH_ENV: tmp_path.as_posix()})
-    return _runner
-
-
-def test_fast_update(runner: CliRunner):
-    _ = runner.invoke(config, ["api.page_limit", "10000"])
+def test_fast_update(tmp_path):
+    InstallConfig.setup(tmp_path)
+    install_path = tmp_path / "esgpull"
+    runner = CliRunner()
+    result_install = runner.invoke(install, [f"{install_path}"])
+    assert result_install.exit_code == 0
+    result_config = runner.invoke(config, ["api.page_limit", "10000"])
+    assert result_config.exit_code == 0
     result_add = runner.invoke(
         add,
         [
@@ -32,9 +27,10 @@ def test_fast_update(runner: CliRunner):
             "--track",
         ],
     )
+    assert result_add.exit_code == 0
     start = perf_counter()
     result_update = runner.invoke(update, ["--yes"])
     stop = perf_counter()
-    assert result_add.exit_code == 0
     assert result_update.exit_code == 0
     assert stop - start < 30  # 30 seconds to fetch ~6k files is plenty enough
+    InstallConfig.setup()

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -21,7 +21,7 @@ def runner(tmp_path):
 
 
 def test_fast_update(runner: CliRunner):
-    result_update = runner.invoke(config, ["api.page_limit", "10000"])
+    _ = runner.invoke(config, ["api.page_limit", "10000"])
     result_add = runner.invoke(
         add,
         [

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,0 +1,40 @@
+from time import perf_counter
+
+import pytest
+from click.testing import CliRunner
+
+from esgpull.cli.add import add
+from esgpull.cli.config import config
+from esgpull.cli.update import update
+from esgpull.constants import INSTALLS_PATH_ENV
+from esgpull.install_config import _InstallConfig
+
+
+@pytest.fixture
+def runner(tmp_path):
+    InstallConfig = _InstallConfig(tmp_path)
+    idx = InstallConfig.add(tmp_path / "esgpull")
+    InstallConfig.choose(idx=idx)
+    InstallConfig.write()
+    _runner = CliRunner(env={INSTALLS_PATH_ENV: tmp_path.as_posix()})
+    return _runner
+
+
+def test_fast_update(runner: CliRunner):
+    result_update = runner.invoke(config, ["api.page_limit", "10000"])
+    result_add = runner.invoke(
+        add,
+        [
+            "table_id:fx",
+            "experiment_id:dcpp*",
+            "--distrib",
+            "false",
+            "--track",
+        ],
+    )
+    start = perf_counter()
+    result_update = runner.invoke(update, ["--yes"])
+    stop = perf_counter()
+    assert result_add.exit_code == 0
+    assert result_update.exit_code == 0
+    assert stop - start < 30  # 30 seconds to fetch ~6k files is plenty enough

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -7,7 +7,8 @@ from esgpull.models import Selection
 @pytest.fixture
 def selection():
     Selection.configure("a", "b", "c", "d", replace=True)
-    return Selection()
+    yield Selection()
+    Selection.reset()
 
 
 def test_configure():
@@ -16,11 +17,12 @@ def test_configure():
     assert new_names <= Selection._facet_names
     Selection.configure("some", "thing", replace=True)
     assert new_names == Selection._facet_names
+    sel = Selection()
     with pytest.raises(KeyError):
-        sel = Selection()
         assert sel["a"] == []
     Selection.configure("a")  # add 'a' to facets
     assert sel["a"] == []  # no more raise
+    Selection.reset()
 
 
 def test_basic(selection):


### PR DESCRIPTION
## New

* Database: add `Database.commit_context()` for easier bulk transactions

## Changed

* Database: add a few sqlite PRAGMAs for more aggressive performance
* cli.update: directly insert & delete into `query_file` table, instead of relying on the ORM
* cli.update: bulk inserts for each query instead of one commit per file


### Example

I created and filled this database in a few minutes with large queries that previously took hours to run, now a good chunk of the time is spent on fetching metadata from index nodes:

```shell
$ esgpull show
<853631>
├── distrib:   True 
│   latest:    True 
│   replica:   None 
│   retracted: False
│   table_id:  fx   
└── <1124a9>
    └── distrib:       True 
        latest:        True 
        replica:       None 
        retracted:     False
        experiment_id: dcpp*
<c95ebd>
└── distrib:       True  
    latest:        True  
    replica:       None  
    retracted:     False 
    experiment_id: ssp245
    frequency:     day   
    variant_label: r1i*  
<cc2c09>
├── distrib:       True       
│   latest:        True       
│   replica:       None       
│   retracted:     False      
│   frequency:     day        
│   variable_id:   tas, tasmax
│   variant_label: r1i*       
└── <ef4f6f>
    └── distrib:       True                        
        latest:        True                        
        replica:       None                        
        retracted:     False                       
        experiment_id: ssp245                      
        files:         0 bytes / 338.8 GiB [0/2206]

$ time esgpull update -y
<1124a9> -> 60759 files.
<853631> -> 191146 files.
<c95ebd> -> 126748 files.
<cc2c09> -> 227623 files.
<ef4f6f> -> 6724 files.
613000 files found.
<1124a9> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:32
<853631> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:01:18
<c95ebd> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:48
<cc2c09> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:01:43
<ef4f6f> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
esgpull update -y  419.46s user 11.52s system 93% cpu 7:41.62 total
```

Running a similar test over a non-empty database (~1.4GB) produces **no significant difference**:

```shell
$ esgpull show cc2c -c
<cc2c09>
├── distrib:       True       
│   latest:        True       
│   replica:       None       
│   retracted:     False      
│   frequency:     day        
│   variable_id:   tas, tasmax
│   variant_label: r1i*       
└── <ef4f6f>
    └── distrib:       True  
        latest:        True  
        replica:       None  
        retracted:     False 
        experiment_id: ssp245

$ time esgpull update cc2c -c -y
<cc2c09> -> 227623 files.
<ef4f6f> -> 6724 files.
234347 files found.
<cc2c09> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:01:49
<ef4f6f> ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:01
esgpull update cc2c -c -y  170.65s user 4.87s system 87% cpu 3:21.09 total
```

Before the current PR, a non-empty database would take longer to update. Multiple reasons made it very inefficient SQL to add a new relation to a query for a file that already had existing relations to other queries. This is now a single insert in all cases, which makes it irrelevant for the database to be empty or not.