### PR TITLE
add --export option on esgpull update

### DIFF
--- a/esgpull/cli/decorators.py
+++ b/esgpull/cli/decorators.py
@@ -109,6 +109,11 @@ class opts:
         is_flag=True,
         default=False,
     )
+    export: Dec = click.option(
+        "--export",
+        is_flag=True,
+        default=False,
+    )
     facets_hints: Dec = click.option(
         "facets_hints",
         "--facets",

--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -140,8 +140,9 @@ def update(
             new_files = [file for file in qf.files if file.sha not in shas]
             nb_files = len(new_files)
             if export:
-                for descrip, file_list, dfl_fn in [("all files", qf.files, "all_files.json"),
-                                                   ("new files", new_files, "new_files.json")]:
+                hash = qf.query.name.strip("<>")
+                for descrip, file_list, dfl_fn in [("all files", qf.files, f"{hash}_all_files.json"),
+                                                   ("new files", new_files, f"{hash}_new_files.json")]:
                     fn = esg.ui.prompt(f"Filename to export {descrip} list:", dfl_fn)
                     with open(fn, "w") as fout:
                         json.dump([file.asdict() for file in file_list],


### PR DESCRIPTION
Adds a `--export` option on `esgpull update` in order to extract lists of files that would be added to the download queue (before the point where it asks the question about whether to add them, or exists if there are no new files)

This gives the user an opportunity to properly inspect what URLs the query is matching, before committing to add the files to the queue.

Two lists of dictionaries are written, in JSON format (after prompting for the filenames, with reasonable defaults):
 - all files (before filtering to remove existing SHAs)
 - new files that will be added

(PR also simplifies a loop with a list comprehension, not directly related to the new option.)