### PR TITLE
Use configured API index node only when querying ESGF nodes during `esgpull update`

### DIFF
--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -100,12 +100,20 @@ def update(
         #   It might be interesting for the special case where all files already
         #   exist in db, then the detailed fetch could be skipped.
         for qf in qfs:
-            qf_results = esg.context.prepare_search_distributed(
-                qf.expanded,
-                file=True,
-                hints=[qf.hints],
-                max_hits=None,
-            )
+            if esg.config.api.use_custom_distribution_algorithm:
+                qf_results = esg.context.prepare_search_distributed(
+                    qf.expanded,
+                    file=True,
+                    hints=[qf.hints],
+                    max_hits=None,
+                )
+            else:
+                qf_results = esg.context.prepare_search(
+                    qf.expanded,
+                    file=True,
+                    hits=[qf.hits],
+                    max_hits=None,
+                )
             nb_req = len(qf_results)
             if nb_req > 50:
                 msg = (

--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -126,6 +126,7 @@ class API:
     page_limit: int = 50
     default_options: DefaultOptions = Factory(DefaultOptions)
     default_query_id: str = ""
+    use_custom_distribution_algorithm: bool = False
 
 
 def fix_rename_search_api(doc: TOMLDocument) -> TOMLDocument:


### PR DESCRIPTION
This PR addresses https://github.com/ESGF/esgf-download/issues/67

`esgpull update` was querying multiple index nodes even when a specific node was configured via `api.index_node`. The custom distribution algorithm that queries multiple index nodes is now opt-in behavior, while the default behavior now honors the configured index node and relies on Solr for the distribution.

Previously, esgpull would:
1. Query the configured index node with `distrib=true` to get facet counts for index nodes
2. Then query each index node directly with `distrib=false` to get actual file lists

This is a problem if an index_node is not responding and is the only one serving some files, then those files won't be collected, even if the data_nodes actually serving the files would be responding.

### Changes
- Added a new configuration option `api.use_custom_distribution_algorithm` (default: `false`)
- When `false`, esgpull uses only the configured `api.index_node` with `distrib=true`
- When `true`, it continues to use the previous behavior of querying multiple nodes