### PR TITLE
feat: improve add message to include next steps (update)

### DIFF
--- a/esgpull/cli/add.py
+++ b/esgpull/cli/add.py
@@ -89,6 +89,7 @@ def add(
         esg.ui.print(subgraph)
         empty = Query()
         empty.compute_sha()
+        next_steps_queries = []
         for query in queries:
             query.compute_sha()
             esg.graph.resolve_require(query)
@@ -99,7 +100,8 @@ def add(
                 esg.ui.print(f"Skipping existing query: {query.rich_name}")
             else:
                 esg.graph.add(query)
-                esg.ui.print(f"New query added: {query.rich_name}")
+                if query.tracked:
+                    next_steps_queries.append(query)
         new_queries = esg.graph.merge()
         nb = len(new_queries)
         ies = "ies" if nb > 1 else "y"
@@ -107,4 +109,8 @@ def add(
             esg.ui.print(f":+1: {nb} new quer{ies} added.")
         else:
             esg.ui.print(":stop_sign: No new query was added.")
+        if next_steps_queries:
+            esg.ui.print("\nNext steps:\n")
+            for query in next_steps_queries:
+                esg.ui.print(f"\tesgpull update {query.sha[:6]}")
         esg.ui.raise_maybe_record(Exit(0))


### PR DESCRIPTION
Previously, the `esgpull add ...` output looked like
```sh
$ esgpull add --query-file queries.json
<8ffe8d>
│ added    2025-05-26T09:39:50Z
│ updated  2025-05-26T09:39:50Z
└── distrib:     False
    latest:      True 
    replica:     None 
    retracted:   False
    variable_id: rsu  
<bf09b3>
│ added    2025-05-26T09:39:46Z
│ updated  2025-05-26T09:39:46Z
└── distrib:     False
    latest:      True 
    replica:     None 
    retracted:   False
    variable_id: tas  
New query added: <8ffe8d>
New query added: <bf09b3>
👍 2 new queries added.
```


With the changes, it looks like:
```sh
$ esgpull add --query-file queries.json
<8ffe8d>
│ added    2025-05-26T09:39:50Z
│ updated  2025-05-26T09:39:50Z
└── distrib:     False
    latest:      True 
    replica:     None 
    retracted:   False
    variable_id: rsu  
<bf09b3>
│ added    2025-05-26T09:39:46Z
│ updated  2025-05-26T09:39:46Z
└── distrib:     False
    latest:      True 
    replica:     None 
    retracted:   False
    variable_id: tas  
👍 2 new queries added.

Next steps:

        esgpull update 8ffe8d
        esgpull update bf09b3
```