### PR TITLE
fix: disable lnll within custom distribution algorithm

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, TypeAlias, TypeVar
+from warnings import warn
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
@@ -404,6 +405,14 @@ class Context:
                 fields_param = FileFieldParams
             else:
                 fields_param = DatasetFieldParams
+        for hint in hints:
+            popped = hint["index_node"].pop("esgf-node.llnl.gov", None)
+            if popped:
+                warn(
+                    f"Skipping {popped} files from esgf-node.llnl.gov\n"
+                    "To avoid skipping this index_node, disable the custom distribution algorithm and re-run the update\n"
+                    "\tesgpull config api.use_custom_distribution_algorithm false"
+                )
         hits = self.hits_from_hints(*hints)
         if max_hits is not None:
             hits = _distribute_hits_impl(hits, max_hits)

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -131,7 +131,8 @@ def test_search_distributed(ctx):
         datasets_distributed = ctx._sync(coro)
     dataset_ids_regular = {d.dataset_id for d in datasets_regular}
     dataset_ids_distributed = {d.dataset_id for d in datasets_distributed}
-    assert dataset_ids_regular == dataset_ids_distributed
+    # After disabling llnl, these sets are not always equal anymore.
+    assert dataset_ids_regular >= dataset_ids_distributed
     # assert t_regular.duration >= t_distributed.duration
     logging.info(f"{t_regular.duration}")
     logging.info(f"{t_distributed.duration}")


### PR DESCRIPTION
This only impacts the `update` command when the config value for `api.use_custom_distribution_algorithm` is `true`, it defaults to `false` so this should have minimal impact.
I added a warning, just in case, to suggest disabling the custom distribution algorithm.