### PR TITLE
fix: handle esgf 1.5 bridge api

### DIFF
--- a/esgpull/utils.py
+++ b/esgpull/utils.py
@@ -63,4 +63,8 @@ def url2index(url: str) -> str:
 
 
 def index2url(index: str) -> str:
-    return "https://" + url2index(index) + "/esg-search/search"
+    url = "https://" + url2index(index)
+    if "esgf-1-5-bridge" in index:
+        return url
+    else:
+        return url + "/esg-search/search"


### PR DESCRIPTION
```
$ uv run esgpull self install .test
Using CPython 3.12.7
Creating virtual environment at: .venv
      Built esgpull @ file:///home/srodriguez/ipsl/esg-pull-worktree/dev-api-bridge
Installed 39 packages in 56ms
────────────────────────────────────────────────────────────────────────── esgpull installation ──────────────────────────────────────────────────────────────────────────
Creating install directory and files at /home/srodriguez/ipsl/esg-pull-worktree/dev-api-bridge/.test
Install config added to /home/srodriguez/.config/esgpull/installs.json

$ uv run esgpull config api.index_node esgf-node.ornl.gov/esgf-1-5-bridge
[api]
index_node = "esgf-node.ornl.gov/esgf-1-5-bridge"

👍 New config file created at /home/srodriguez/ipsl/esg-pull-worktree/dev-api-bridge/.test/config.toml.

$ uv run esgpull search
Found 20110593 datasets.
 id │                                         dataset                                          │ # │   size    
════╪══════════════════════════════════════════════════════════════════════════════════════════╪═══╪═══════════
  0 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r281i1p1f2.Amon.rlutcs.gr.v20210127      │ 1 │   1.1 MiB 
  1 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r281i1p1f2.Amon.sbl.gr.v20210127         │ 1 │ 665.2 kiB 
  2 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r281i1p1f2.Eday.rivo.gn.v20210127        │ 1 │ 127.7 MiB 
  3 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r281i1p1f2.Emon.grassFracC3.gr.v20210127 │ 1 │ 485.6 kiB 
  4 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r281i1p1f2.day.uas.gr.v20210127          │ 1 │  41.8 MiB 
  5 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r282i1p1f2.CFday.ps.gr.v20210127         │ 1 │  31.5 MiB 
  6 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r282i1p1f2.Eday.rivo.gn.v20210127        │ 1 │ 127.7 MiB 
  7 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r282i1p1f2.Emon.mrtws.gr.v20210127       │ 1 │ 640.0 kiB 
  8 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r282i1p1f2.Emon.rss.gr.v20210127         │ 1 │   1.2 MiB 
  9 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r282i1p1f2.fx.zfull.gr.v20210127         │ 1 │  12.5 MiB 
 10 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r283i1p1f2.Amon.hfss.gr.v20210127        │ 1 │   1.4 MiB 
 11 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r283i1p1f2.Amon.rldscs.gr.v20210127      │ 1 │   1.1 MiB 
 12 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r283i1p1f2.Amon.rsuscs.gr.v20210127      │ 1 │   1.1 MiB 
 13 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r283i1p1f2.Emon.grassFracC3.gr.v20210127 │ 1 │ 485.6 kiB 
 14 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r283i1p1f2.Emon.grassFracC4.gr.v20210127 │ 1 │ 343.4 kiB 
 15 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r284i1p1f2.Amon.prw.gr.v20210127         │ 1 │   1.3 MiB 
 16 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r284i1p1f2.Amon.rldscs.gr.v20210127      │ 1 │   1.1 MiB 
 17 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r284i1p1f2.Amon.rsutcs.gr.v20210127      │ 1 │   1.1 MiB 
 18 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r284i1p1f2.Amon.va.gr.v20210127          │ 1 │  24.9 MiB 
 19 │ CMIP6.PAMIP.CNRM-CERFACS.CNRM-CM6-1.pdSST-pdSIC.r284i1p1f2.Lmon.rh.gr.v20210127          │ 1 │ 550.1 kiB
```