### PR TITLE
fix(plugins): call .unwrap() on loaded config from tomlkit

### DIFF
--- a/esgpull/cli/plugins.py
+++ b/esgpull/cli/plugins.py
@@ -337,7 +337,7 @@ from datetime import datetime
 from pathlib import Path
 from logging import Logger
 
-from esgpull.models import File, Query
+from esgpull.models import Dataset, File, Query
 from esgpull.plugin import Event, on
 
 # Specify version compatibility (optional)


### PR DESCRIPTION
 `tomlkit` uses its own types, that pydantic does not know about.
It seems to work for ints, but strings are problematic.
Other toml libraries don't preserve comments upon writing, so the
solution is simply to unwrap the "raw" config into python types.
Also store the whole config instead of only the "plugins" sub-tree in
the "raw" property, to preserve the full file state upon writes.