### PR TITLE
Fix bridge api extra parameters

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -101,7 +101,10 @@ class Result:
             else:
                 if len(values) > 1:
                     value_term = f"({value_term})"
-                solr_terms.append(f"{name}:{value_term}")
+                if name.startswith("!"):
+                    solr_terms.append(f"(NOT {name[1:]}:{value_term})")
+                else:
+                    solr_terms.append(f"{name}:{value_term}")
         if solr_terms:
             params["query"] = " AND ".join(solr_terms)
         for name, option in self.query.options.items(use_default=True):

--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, TypeAlias, TypeVar
+from urllib.parse import urlparse
 
 if sys.version_info < (3, 11):
     from exceptiongroup import BaseExceptionGroup
@@ -18,7 +19,7 @@ from esgpull.config import Config
 from esgpull.exceptions import SolrUnstableQueryError
 from esgpull.models import DatasetRecord, File, Query
 from esgpull.tui import logger
-from esgpull.utils import format_date_iso, index2url, sync
+from esgpull.utils import format_date_iso, sync
 
 # workaround for notebooks with running event loop
 if asyncio.get_event_loop().is_running():
@@ -37,6 +38,29 @@ DangerousFacets = {
     "tracking_id",
     "url",
 }
+
+
+@dataclass
+class IndexNode:
+    value: str
+
+    def is_bridge(self) -> bool:
+        return "esgf-1-5-bridge" in self.value
+
+    @property
+    def url(self) -> str:
+        parsed = urlparse(self.value)
+        result: str
+        match (parsed.scheme, parsed.netloc, parsed.path, self.is_bridge()):
+            case ("", "", path, True):
+                result = "https://" + parsed.path
+            case ("", "", path, False):
+                result = "https://" + parsed.path + "/esg-search/search"
+            case _:
+                result = self.value
+        if "." not in result:
+            raise ValueError(self.value)
+        return result
 
 
 @dataclass
@@ -70,12 +94,12 @@ class Result:
             "format": "application/solr+json",
             # "from": self.since,
         }
-        if index_url is None:
-            index_url = index2url(index_node)
-        if fields_param is not None:
-            params["fields"] = ",".join(fields_param)
-        else:
-            params["fields"] = "instance_id"
+        index = IndexNode(value=index_url or index_node)
+        if not index.is_bridge():
+            if fields_param is not None:
+                params["fields"] = ",".join(fields_param)
+            else:
+                params["fields"] = "instance_id"
         if date_from is not None:
             params["from"] = format_date_iso(date_from)
         if date_to is not None:
@@ -110,9 +134,11 @@ class Result:
         for name, option in self.query.options.items(use_default=True):
             if option.is_bool():
                 params[name] = option.name
+        if index.is_bridge():
+            _ = params.pop("retracted", None)  # not supported in bridge API
         if params.get("distrib") == "true" and facets_star:
             raise SolrUnstableQueryError(pretty_repr(self.query))
-        self.request = Request("GET", index_url, params=params)
+        self.request = Request("GET", index.url, params=params)
 
     def to(self, subtype: type[RT]) -> RT:
         result: RT = subtype(self.query, self.file)

--- a/esgpull/utils.py
+++ b/esgpull/utils.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 from typing import Callable, Coroutine, TypeVar
-from urllib.parse import urlparse
 
 from rich.filesize import _to_str
 
@@ -52,19 +51,3 @@ def format_date_iso(
     date: str | datetime.datetime, fmt: str = "%Y-%m-%d"
 ) -> str:
     return parse_date(date, fmt).replace(microsecond=0).isoformat() + "Z"
-
-
-def url2index(url: str) -> str:
-    parsed = urlparse(url)
-    if parsed.netloc == "":
-        return parsed.path
-    else:
-        return parsed.netloc
-
-
-def index2url(index: str) -> str:
-    url = "https://" + url2index(index)
-    if "esgf-1-5-bridge" in index:
-        return url
-    else:
-        return url + "/esg-search/search"

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -104,6 +104,10 @@ class Timer:
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(
+    raises=ValueError,
+    reason="ESGF bridge API gives index_node values that are not valid URLs",
+)
 def test_search_distributed(ctx):
     query = Query()
     # ctx.config.api.http_timeout = 60
@@ -138,7 +142,12 @@ def test_search_distributed(ctx):
 
 
 def test_ipsl_hits_between_1_and_2_million(ctx, cmip6_ipsl):
-    assert 1_000_000 < ctx.hits(cmip6_ipsl, file=False)[0] < 2_000_000
+    hits = ctx.hits(
+        cmip6_ipsl,
+        file=False,
+        index_node="esgf-node.ipsl.upmc.fr",
+    )
+    assert 1_000_000 < hits[0] < 2_000_000
 
 
 def test_more_files_than_datasets(ctx, query):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,7 @@ from time import perf_counter
 
 import pytest
 
-from esgpull.context import Context
+from esgpull.context import Context, IndexNode
 from esgpull.models import Query
 
 
@@ -177,3 +177,35 @@ def test_ignore_facet_hits(ctx):
     hits_not_ipsl = ctx.hits(query_not_ipsl, file=False)[0]
     assert all(hits > 0 for hits in [hits_all, hits_ipsl, hits_not_ipsl])
     assert hits_all == hits_ipsl + hits_not_ipsl
+
+
+@pytest.mark.parametrize(
+    "index,url,is_bridge",
+    [
+        (
+            "esgf-node.ipsl.upmc.fr",
+            "https://esgf-node.ipsl.upmc.fr/esg-search/search",
+            False,
+        ),
+        (
+            "https://esgf-node.ipsl.upmc.fr/esg-search/search",
+            "https://esgf-node.ipsl.upmc.fr/esg-search/search",
+            False,
+        ),
+        (
+            "esgf-node.ornl.gov/esgf-1-5-bridge",
+            "https://esgf-node.ornl.gov/esgf-1-5-bridge",
+            True,
+        ),
+        (
+            "https://esgf-node.ornl.gov/esgf-1-5-bridge",
+            "https://esgf-node.ornl.gov/esgf-1-5-bridge",
+            True,
+        ),
+    ],
+)
+def test_index2url(index: str, url: str, is_bridge: bool):
+    for value in (index, url):
+        index_node = IndexNode(value=value)
+        assert index_node.url == url
+        assert index_node.is_bridge() == is_bridge

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,10 +2,7 @@ from datetime import datetime
 
 import pytest
 
-from esgpull.utils import format_date, format_date_iso, index2url, parse_date
-
-ESGF_INDEX = "esgf-node.ipsl.upmc.fr"
-ESGF_URL = "https://esgf-node.ipsl.upmc.fr/esg-search/search"
+from esgpull.utils import format_date, format_date_iso, parse_date
 
 
 def test_parse_date():
@@ -40,8 +37,3 @@ def test_format_date_iso():
         format_date_iso("20220101")
     with pytest.raises(ValueError):
         format_date_iso(20220101)
-
-
-def test_index2url():
-    assert index2url(ESGF_INDEX) == ESGF_URL
-    assert index2url(ESGF_URL) == ESGF_URL


### PR DESCRIPTION
Resolves https://github.com/ESGF/esgf-download/issues/93

Some query parameters are invalid with the bridge API -> removed when the index is detected as bridge API:
* `retracted`
* `fields`

A few additional issues appeared after running esgpull's test suite on the bridge API:
* it does not support esgpull's `use_custom_distribution_algorithm`: the returned `index_node` values in `facet_counts` are not always valid URLs ([example](https://esgf-node.ornl.gov/esgf-1-5-bridge?type=Dataset&offset=0&limit=0&format=application%2Fsolr%2Bjson&facets=index_node&query=member_id%3Ar20i1p1f1+AND+mip_era%3ACMIP6+AND+table_id%3AAmon+AND+variable_id%3Atas&distrib=true&latest=true) that gives `us-index`)
  * no fix here, should an explicit error be raised when the conflicting config entries are found?
* it does not support the solr syntax used to exclude part of a search query with `!name:value` 
  * replacing with `(NOT name:value)` works
* it does not support `facets=*`, used when searching with `--facets` flag
  * rework the logic to show all keys from the first file result instead, this assumption is wrong across projects but works most of the time