### PR TITLE
Fix tests ipsl expired ssl

### DIFF
--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -1,34 +1,26 @@
+from pathlib import Path
+
 from click.testing import CliRunner
 
 from esgpull import Esgpull
 from esgpull.cli.add import add
-from esgpull.cli.config import config
+from esgpull.cli.config import config as config_cmd
 from esgpull.cli.remove import remove
-from esgpull.cli.self import install
 from esgpull.cli.update import update
-from esgpull.install_config import InstallConfig
+from esgpull.config import Config
 
 
-def test_update_after_remove(tmp_path):
-    InstallConfig.setup(tmp_path)
-    install_path = tmp_path / "esgpull"
+def test_update_after_remove(root: Path, config: Config):
+    config.generate(overwrite=True)
     runner = CliRunner()
-    result_install = runner.invoke(install, [f"{install_path}"])
-    assert result_install.exit_code == 0
-    result_config = runner.invoke(config, ["api.page_limit", "10000"])
+    result_config = runner.invoke(config_cmd, ["api.page_limit", "10000"])
     assert result_config.exit_code == 0
     result_add = runner.invoke(
         add,
         [
             "activity_id:CMIP",
             "experiment_id:1pctCO2",
-            "frequency:fx",
-            "institution_id:CNRM-CERFACS",
-            "member_id:r9i1p1f2",
             "source_id:CNRM-ESM2-1",
-            "table_id:fx",
-            "variable:areacella",
-            "variable_id:areacella",
             "--distrib",
             "false",
             "--track",
@@ -38,7 +30,7 @@ def test_update_after_remove(tmp_path):
     result_update = runner.invoke(update, ["--yes"])
     assert result_update.exit_code == 0
 
-    esg = Esgpull(install_path)  # Reinitialize to ensure fresh data
+    esg = Esgpull(root)  # Reinitialize to ensure fresh data
     esg.graph.load_db()
     query_id = list(esg.graph._shas)[0]
     query = esg.graph.get(query_id)
@@ -53,13 +45,7 @@ def test_update_after_remove(tmp_path):
         [
             "activity_id:CMIP",
             "experiment_id:1pctCO2",
-            "frequency:fx",
-            "institution_id:CNRM-CERFACS",
-            "member_id:r9i1p1f2",
             "source_id:CNRM-ESM2-1",
-            "table_id:fx",
-            "variable:areacella",
-            "variable_id:areacella",
             "--distrib",
             "false",
             "--track",
@@ -69,8 +55,6 @@ def test_update_after_remove(tmp_path):
     result_update = runner.invoke(update, ["--yes"])
     assert result_update.exit_code == 0
 
-    esg = Esgpull(install_path)  # Reinitialize to ensure fresh data
+    esg = Esgpull(root)  # Reinitialize to ensure fresh data
     query = esg.graph.get(query_id)
     assert nb_files_after_update == len(query.files)
-
-    InstallConfig.setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,27 +1,34 @@
+from pathlib import Path
+
 import pytest
 
 from esgpull.config import Config
 from esgpull.constants import CONFIG_FILENAME
 from esgpull.install_config import InstallConfig
 from esgpull.models import File, FileStatus
+from tests.utils import CEDA_NODE
 
 
 @pytest.fixture
-def root(tmp_path):
+def root(tmp_path: Path):
+    InstallConfig.setup(install_path=tmp_path)
     idx = InstallConfig.add(tmp_path / "esgpull")
     InstallConfig.choose(idx=idx)
+    InstallConfig.write()
     return InstallConfig.installs[idx].path
 
 
 @pytest.fixture
-def config_path(root):
+def config_path(root: Path):
     return root / CONFIG_FILENAME
 
 
 @pytest.fixture
-def config(root):
+def config(root: Path):
     cfg = Config.load(root)
-    cfg.paths.db.mkdir(parents=True)
+    for p in cfg.paths.values():
+        p.mkdir(parents=True, exist_ok=True)
+    cfg.api.index_node = CEDA_NODE
     return cfg
 
 

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -3,8 +3,7 @@ import pytest
 from esgpull.database import Database
 from esgpull.graph import Graph
 from esgpull.models import Query
-
-from .utils import dict_equals_ignore
+from tests.utils import dict_equals_ignore
 
 
 @pytest.fixture

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 
 import httpx
 import pytest
@@ -8,47 +9,142 @@ from esgpull.models import File
 from esgpull.processor import Task
 from esgpull.result import Ok
 
+FILE_JSON: dict = json.loads("""
+{
+  "id": "CMIP6.AerChemMIP.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.r1i1p1f2.fx.sftlf.gr.v20190621.sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc|esgf.ceda.ac.uk",
+  "version": "1",
+  "activity_drs": [
+    "AerChemMIP"
+  ],
+  "activity_id": [
+    "AerChemMIP"
+  ],
+  "cf_standard_name": [
+    "land_area_fraction"
+  ],
+  "checksum": [
+    "cfdc9d9113d8ab81dd51f5b133267e2d3d4db830ee0a399b444cbb1d540f512e"
+  ],
+  "checksum_type": [
+    "SHA256"
+  ],
+  "citation_url": [
+    "http://cera-www.dkrz.de/WDCC/meta/CMIP6/CMIP6.AerChemMIP.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.r1i1p1f2.fx.sftlf.gr.v20190621.json"
+  ],
+  "data_node": "esgf.ceda.ac.uk",
+  "data_specs_version": [
+    "01.00.21"
+  ],
+  "dataset_id": "CMIP6.AerChemMIP.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.r1i1p1f2.fx.sftlf.gr.v20190621|esgf.ceda.ac.uk",
+  "dataset_id_template_": [
+    "%(mip_era)s.%(activity_drs)s.%(institution_id)s.%(source_id)s.%(experiment_id)s.%(member_id)s.%(table_id)s.%(variable_id)s.%(grid_label)s"
+  ],
+  "directory_format_template_": [
+    "%(root)s/%(mip_era)s/%(activity_drs)s/%(institution_id)s/%(source_id)s/%(experiment_id)s/%(member_id)s/%(table_id)s/%(variable_id)s/%(grid_label)s/%(version)s"
+  ],
+  "experiment_id": [
+    "hist-1950HC"
+  ],
+  "experiment_title": [
+    "historical forcing, but with1950s halocarbon concentrations; initialized in 1950"
+  ],
+  "frequency": [
+    "fx"
+  ],
+  "further_info_url": [
+    "https://furtherinfo.es-doc.org/CMIP6.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.none.r1i1p1f2"
+  ],
+  "grid": [
+    "data regridded to a T127 gaussian grid (128x256 latlon) from a native atmosphere T127l reduced gaussian grid"
+  ],
+  "grid_label": [
+    "gr"
+  ],
+  "index_node": "esgf.ceda.ac.uk",
+  "instance_id": "CMIP6.AerChemMIP.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.r1i1p1f2.fx.sftlf.gr.v20190621.sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc",
+  "institution_id": [
+    "CNRM-CERFACS"
+  ],
+  "latest": true,
+  "master_id": "CMIP6.AerChemMIP.CNRM-CERFACS.CNRM-ESM2-1.hist-1950HC.r1i1p1f2.fx.sftlf.gr.sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc",
+  "member_id": [
+    "r1i1p1f2"
+  ],
+  "metadata_format": "THREDDS",
+  "mip_era": [
+    "CMIP6"
+  ],
+  "model_cohort": [
+    "Registered"
+  ],
+  "nominal_resolution": [
+    "250 km"
+  ],
+  "pid": [
+    "hdl:21.14100/37f7d29f-8d1f-354f-8554-f71adda35d22"
+  ],
+  "product": [
+    "model-output"
+  ],
+  "project": [
+    "CMIP6"
+  ],
+  "realm": [
+    "atmos"
+  ],
+  "replica": true,
+  "size": 53605,
+  "source_id": [
+    "CNRM-ESM2-1"
+  ],
+  "source_type": [
+    "AOGCM",
+    "BGC",
+    "AER",
+    "CHEM"
+  ],
+  "sub_experiment_id": [
+    "none"
+  ],
+  "table_id": [
+    "fx"
+  ],
+  "timestamp": "2020-03-10T01:53:55Z",
+  "title": "sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc",
+  "tracking_id": [
+    "hdl:21.14100/70b80649-e719-48df-9e3b-a7b7299c1c3c"
+  ],
+  "type": "File",
+  "url": [
+    "https://esgf.ceda.ac.uk/thredds/fileServer/esg_cmip6/CMIP6/AerChemMIP/CNRM-CERFACS/CNRM-ESM2-1/hist-1950HC/r1i1p1f2/fx/sftlf/gr/v20190621/sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc|application/netcdf|HTTPServer",
+    "https://esgf.ceda.ac.uk/thredds/dodsC/esg_cmip6/CMIP6/AerChemMIP/CNRM-CERFACS/CNRM-ESM2-1/hist-1950HC/r1i1p1f2/fx/sftlf/gr/v20190621/sftlf_fx_CNRM-ESM2-1_hist-1950HC_r1i1p1f2_gr.nc.html|application/opendap-html|OPENDAP"
+  ],
+  "variable": [
+    "sftlf"
+  ],
+  "variable_id": [
+    "sftlf"
+  ],
+  "variable_long_name": [
+    "Land Area Fraction"
+  ],
+  "variable_units": [
+    "%"
+  ],
+  "variant_label": [
+    "r1i1p1f2"
+  ],
+  "retracted": false,
+  "_timestamp": "2020-03-11T20:36:07.909Z",
+  "score": 7.750845,
+  "_version_": 1803414002300092400
+}
+""")
+
 
 @pytest.fixture
 def smallfile():
-    dataset_id = (
-        "CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r10i1p1f1.Eyr.cLitterLut.gr"
-        ".v20180803"
-    )
-    dataset_master, version = dataset_id.rsplit(".", 1)
-    filename = (
-        "cLitterLut_Eyr_IPSL-CM6A-LR_historical_r10i1p1f1_gr_1851-2015.nc"
-    )
-    file_id = ".".join([dataset_id, filename])
-    master_id = ".".join([dataset_master, filename])
-    data_node = "vesg.ipsl.upmc.fr"
-    host = f"https://{data_node}/thredds/fileServer"
-    url = "/".join(
-        [
-            host,
-            "cmip6",
-            *dataset_id.split(".")[1:],
-            filename,
-        ]
-    )
-    checksum = (
-        "47958756e90cb6afcd20451dcd138b4ced1e1845afdd1ea12c1f962991da2f87"
-    )
-    file = File(
-        file_id=file_id,
-        dataset_id=dataset_id,
-        master_id=master_id,
-        url=url,
-        version=version,
-        filename=filename,
-        local_path=dataset_id.replace(".", "/"),
-        data_node=data_node,
-        checksum=checksum,
-        checksum_type="SHA256",
-        size=6512402,
-    )
-    file.compute_sha()
-    return file
+    return File.serialize(FILE_JSON)
 
 
 @pytest.fixture
@@ -69,10 +165,10 @@ async def run_task(task_):
     return result
 
 
-@pytest.mark.xfail(
-    raises=(httpx.ConnectTimeout, httpx.ReadTimeout),
-    reason="this is dependent on the IPSL data node's health (unstable)",
-)
+# @pytest.mark.xfail(
+#     raises=(httpx.ConnectTimeout, httpx.ReadTimeout),
+#     reason="this is dependent on the IPSL data node's health (unstable)",
+# )
 def test_task(fs, smallfile, task):
     result = asyncio.run(run_task(task))
     if not result.ok:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,8 +2,7 @@ import pytest
 
 from esgpull.exceptions import AlreadySetFacet
 from esgpull.models import Query, Tag
-
-from .utils import dict_equals_ignore
+from tests.utils import dict_equals_ignore
 
 
 def test_empty_asdict():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,10 @@
 from typing import Any, Mapping
 
+IPSL_NODE = "esgf-node.ipsl.upmc.fr"
+DRKZ_NODE = "esgf-data.dkrz.de"
+CEDA_NODE = "esgf.ceda.ac.uk"
+ORNL_BRIDGE = "esgf-node.ornl.gov/esgf-1-5-bridge"
+
 
 def dict_equals_ignore(
     d1: Mapping[str, Any],


### PR DESCRIPTION
#102 must be merged prior to this PR.

Workaround for ipsl node expired SSL cert, as it is currently blocking all other PRs with all tests failing

### Changes

* use CEDA node instead of IPSL for most tests using Context
* use CEDA url for processor test that downloads a file
* disable `search_distributed` test
* broaden hardcoded queries to better match CEDA results

These additional changes are not directly related to the fix but help with forcing the index url in a single pytest fixture:
* fix CLI tests that were not using config fixture
* fix CLI tests creating entries in global installs