### PR TITLE
fix: NOT operator

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -126,7 +126,7 @@ class Result:
                 if len(values) > 1:
                     value_term = f"({value_term})"
                 if name.startswith("!"):
-                    solr_terms.append(f"(NOT {name[1:]}:{value_term})")
+                    solr_terms.append(f"NOT ({name[1:]}:{value_term})")
                 else:
                     solr_terms.append(f"{name}:{value_term}")
         if solr_terms:

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -183,10 +183,17 @@ def test_hits_from_hints(ctx):
     assert hits == [6]
 
 
-def test_ignore_facet_hits(ctx):
-    query_all = Query()
-    query_ipsl = Query(selection={"institution_id": "IPSL"})
-    query_not_ipsl = Query(selection={"!institution_id": "IPSL"})
+@pytest.mark.parametrize(
+    "query_all",
+    [
+        Query(),
+        Query(selection={"variable_id": "tas"}),
+        Query(selection={"experiment_id": "ssp*", "variable_id": "tas"}),
+    ],
+)
+def test_ignore_facet_hits(ctx, query_all: Query):
+    query_ipsl = Query(selection={"institution_id": "IPSL"}) << query_all
+    query_not_ipsl = Query(selection={"!institution_id": "IPSL"}) << query_all
     hits_all = ctx.hits(query_all, file=False)[0]
     hits_ipsl = ctx.hits(query_ipsl, file=False)[0]
     hits_not_ipsl = ctx.hits(query_not_ipsl, file=False)[0]


### PR DESCRIPTION
Resolve https://github.com/ESGF/esgf-download/issues/99

The `NOT` operator was not correctly applied.
The issue only appeared with queries containing more than 1 term, which explains how it was never caught by the existing test case, I added new test cases with additional query terms, which indeed were not passing before the fix.