### PR TITLE
Add cli command to scan index nodes

### DIFF
--- a/esgpull/cli/__init__.py
+++ b/esgpull/cli/__init__.py
@@ -8,6 +8,7 @@ from esgpull.cli.add import add
 from esgpull.cli.config import config
 from esgpull.cli.convert import convert
 from esgpull.cli.download import download
+from esgpull.cli.index_nodes import index_nodes
 from esgpull.cli.plugins import plugins
 from esgpull.cli.remove import remove
 from esgpull.cli.retry import retry
@@ -49,6 +50,7 @@ SUBCOMMANDS: list[click.Command] = [
     status,
     # # stats,
     update,
+    index_nodes,
 ]
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])

--- a/esgpull/cli/index_nodes.py
+++ b/esgpull/cli/index_nodes.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+
+import click
+from click.exceptions import Abort, Exit
+
+from esgpull import Context
+from esgpull.cli.decorators import groups, opts
+from esgpull.cli.utils import init_esgpull, totable
+from esgpull.models import Query
+from esgpull.tui import Verbosity, logger
+
+
+def check_node(c: Context, node: str) -> bool:
+    try:
+        c.probe(index_node=node)
+        return True
+    except:
+        return False
+
+
+def find_nodes(c: Context, node: str) -> list[str]:
+    try:
+        hints = c.hints(
+            Query(), file=False, index_node=node, facets=["index_node"]
+        )
+        return list(hints[0]["index_node"])
+    except:
+        return []
+
+
+@click.command()
+@groups.json_yaml
+@opts.record
+@opts.verbosity
+def index_nodes(
+    ## json_yaml
+    json: bool,
+    yaml: bool,
+    record: bool,
+    verbosity: Verbosity,
+) -> None:
+    """
+    Test index nodes for their current status
+    """
+    esg = init_esgpull(
+        verbosity,
+        safe=False,
+        record=record,
+    )
+    with esg.ui.logging("scan", onraise=Abort):
+        node_status: dict[str, bool] = {}
+        nodes = [
+            "esgf-node.ipsl.upmc.fr",
+            "esgf-data.dkrz.de",
+            "esgf.ceda.ac.uk",
+            "esgf-node.ornl.gov/esgf-1-5-bridge",
+        ]
+
+        esg.config.api.http_timeout = 3
+        with esg.ui.spinner("Fetching index nodes status"):
+            while True:
+                if not nodes:
+                    break
+                node = nodes.pop()
+                if node in node_status:
+                    continue
+                logger.info(f"check: {node}")
+                node_status[node] = check_node(esg.context, node)
+                logger.info(f"{node}\tok: {node_status[node]}")
+                for node in find_nodes(esg.context, node):
+                    if node not in node_status:
+                        nodes.append(node)
+                        logger.info(f"found index_node: {node}")
+        if json:
+            esg.ui.print(node_status, json=True)
+        elif yaml:
+            esg.ui.print(node_status, yaml=True)
+        else:
+            table = [
+                OrderedDict(
+                    [
+                        ("node", node),
+                        (
+                            "status",
+                            "[green]OK" if status else "[red]no response",
+                        ),
+                    ]
+                )
+                for node, status in node_status.items()
+            ]
+            esg.ui.print(totable(table))
+        esg.ui.raise_maybe_record(Exit(0))


### PR DESCRIPTION
~~Leaving as draft as this PR is stacked on top of #110~~

Add a new cli command `esgpull index-nodes` to start a scan for index nodes response, to get feedback on which one is currently available.

This starts with a hardcoded list of index nodes (ipsl, dkrz, ceda, ornl/bridge) and for every OK index, fetches a list of hints for `index_node` that exist in that index' database. I'm not 100% confident that this is exhaustive, we may need to add a few to the hardcoded list to explore all index nodes.

To speed up the scan, the current `api.http_timeout` is overwritten to 3 seconds (arbitrary) for the duration of the scan. 

```shell
$ esgpull index-nodes
                node                │   status    
════════════════════════════════════╪═════════════
 esgf-node.ornl.gov/esgf-1-5-bridge │          OK 
                           us-index │ no response 
                    esgf.ceda.ac.uk │          OK 
             esgf-node.ipsl.upmc.fr │          OK 
                 esg-dn1.nsc.liu.se │          OK 
                    esgf.nci.org.au │          OK 
                  esgf-data.dkrz.de │          OK 
              esgdata.gfdl.noaa.gov │ no response 
                 esgf-node.llnl.gov │ no response
```