### PR TITLE
use get_running_loop instead of get_event_loop

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -22,7 +22,9 @@ from esgpull.tui import logger
 from esgpull.utils import format_date_iso, sync
 
 # workaround for notebooks with running event loop
-if asyncio.get_event_loop().is_running():
+try:
+    asyncio.get_running_loop()
+except RuntimeError:
     import nest_asyncio
 
     nest_asyncio.apply()


### PR DESCRIPTION
Closes #114 

I am no expert of async, so feel free to close if this is not the right solution.
According to the documentation, it is preferable to use [get_running_loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_running_loop) instead of [get_event_loop](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop).

This should also fix incompatibilities with Python 3.14.

