### PR TITLE
Fix bridge quoting

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -68,7 +68,10 @@ class IndexNode:
 
 
 def quote_str(s: str) -> str:
-    if not s.startswith('"') and not s.endswith('"'):
+    if "*" in s:
+        # don't quote when `*` is present, quotes enforce exact match
+        return s
+    elif not s.startswith('"') and not s.endswith('"'):
         return f'"{s}"'
     else:
         return s

--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -67,6 +67,13 @@ class IndexNode:
         return result
 
 
+def quote_str(s: str) -> str:
+    if not s.startswith('"') and not s.endswith('"'):
+        return f'"{s}"'
+    else:
+        return s
+
+
 @dataclass
 class Result:
     query: Query
@@ -123,7 +130,10 @@ class Result:
         #     query["end"] = format_date_iso(str(facets.pop("end")))
         solr_terms: list[str] = []
         for name, values in self.query.selection.items():
-            value_term = " ".join(values)
+            if index.is_bridge():
+                value_term = " ".join(quote_str(v) for v in values)
+            else:
+                value_term = " ".join(values)
             if name == "query":  # freetext case
                 solr_terms.append(value_term)
             else:


### PR DESCRIPTION
Replaces https://github.com/ESGF/esgf-download/pull/106
Closes https://github.com/ESGF/esgf-download/issues/98

## Summary

This PR removes false positive search results reported in #98 , doing so transparently for already quoted values, we dont want to impose changing queries and tools that had incorporated quoting as a workaround already.


## Changes

* quote values when using bridge endpoint, unless:
  * value is already quoted
  * value include `*` (quotes force exact matching)
* add variants of some context tests to use bridge endpoint

## Notes

The query example taken from the issue does actually not return any results (which seems to be the correct behaviour from further exploration):
```shell
$ esgpull search experiment_id:amip-hist variable_id:tas frequency:mon source_id:MPI-ESM1-2-HR variant_label:r1i1p1f1
Found 0 datasets.
```

Changing the experiement to `amip` gives seemingly normal results:
```shell
$ esgpull search experiment_id:amip variable_id:tas frequency:mon source_id:MPI-ESM1-2-HR variant_label:r1i1p1f1
Found 3 datasets.
 id │             dataset              │ # │   size   │       data_node        
════╪══════════════════════════════════╪═══╪══════════╪════════════════════════
  0 │ CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.… │ 8 │ 48.7 MiB │     eagle.alcf.anl.gov 
  1 │ CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.… │ 8 │ 48.7 MiB │ esgf-data04.diasjp.net 
  2 │ CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.… │ 8 │ 48.7 MiB │     esgf-node.ornl.gov
```

A `--hints` search with `amip-hist` (I removed `source_id` from the original query) now correctly tells us only `amip-hist` is used as a search term:
```shell
$ esgpull search experiment_id:amip-hist variable_id:tas frequency:mon variant_label:r1i1p1f1 --hints experiment_id
[
  {
    "experiment_id": {
      "amip-hist": 45
    }
  }
]
```

Below is the same query, using current `main` (fcecf712)
```shell
$ esgpull search experiment_id:amip-hist variable_id:tas frequency:mon variant_label:r1i1p1f1 --hints experiment_id
[
  {
    "experiment_id": {
      "amip": 151,
      "hist-GHG": 49,
      "hist-nat": 47,
      "amip-hist": 45,
      "hist-aer": 44,
      "hist-1950": 43,
      "amip-4xCO2": 28,
      "amip-p4K": 28,
      "hist-noLu": 26,
      "amip-future4K": 24,
      "esm-hist": 22,
      "amip-m4K": 21,
      "amip-piForcing": 19,
      "hist-piAer": 18,
      "amip-lwoff": 17,
      "amip-p4K-lwoff": 17,
      "hist-piNTCF": 16,
      "land-hist": 15,
      "amip-lfmip-pdLC": 14,
      "amip-lfmip-rmLC": 14,
      "hist-sol": 13,
      "hist-resIPO": 12,
      "hist-stratO3": 11,
      "hist-resAMO": 10,
      "hist-volc": 10,
      "land-hist-cruNcep": 9,
      "hist-1950HC": 8,
      "hist-bgc": 8,
      "amip-TIP": 7,
      "amip-TIP-nosh": 7,
      "amip-hld": 7,
      "land-hist-princeton": 7,
      "hist-CO2": 6,
      "hist-totalO3": 6,
      "land-hist-altStartYear": 6,
      "amip-a4SST-4xCO2": 5,
      "hist-spAer-all": 4,
      "hist-GHG-cmip5": 3,
      "hist-aer-cmip5": 3,
      "hist-nat-cmip5": 3,
      "land-hist-wfdei": 3,
      "land-hist-altLu1": 2,
      "land-hist-altLu2": 2,
      "amip-lfmip-pObs": 1
    }
  }
]
```