### PR TITLE
Catching empty hits lists before attempts to index list

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -254,6 +254,10 @@ class ResultSearchAsQueries(Result):
 
 
 def _distribute_hits_impl(hits: list[int], max_hits: int) -> list[int]:
+    # catch empty hits
+    if not hits:
+        return []
+
     i = total = 0
     N = len(hits)
     accs = [0.0 for _ in range(N)]
@@ -279,6 +283,10 @@ def _distribute_hits(
     max_hits: int | None,
     page_limit: int,
 ) -> list[list[slice]]:
+    # early return if no hits
+    if not hits:
+        return []
+
     offsets = _distribute_hits_impl(hits, offset)
     hits_with_offset = [h - o for h, o in zip(hits, offsets)]
     hits = hits[:]


### PR DESCRIPTION
A very small one here!

When no hits are returned by `context`'s `search()`, perhaps due to a time-out or incorrect search string, `context.py`'s `_distribute_hits_impl` attempts to index an empty list. This fails with the following error:
```
Traceback (most recent call last):
  File "../python3.14/site-packages/esgpull/tui.py", line 180, in logging
    yield
  File "../python3.14/site-packages/esgpull/cli/search.py", line 197, in search
    results = esg.context.search(
        query,
    ...<6 lines>...
        date_to=date_to,
    )
  File "../python3.14/site-packages/esgpull/context.py", line 752, in search
    return fun(
        *queries,
    ...<6 lines>...
        keep_duplicates=keep_duplicates,
    )
  File "../python3.14/site-packages/esgpull/context.py", line 665, in datasets
    results = self.prepare_search(
        *queries,
    ...<6 lines>...
        date_to=date_to,
    )
  File "../python3.14/site-packages/esgpull/context.py", line 398, in prepare_search
    slices = _distribute_hits(
        hits=hits,
    ...<2 lines>...
        page_limit=page_limit,
    )
  File "../python3.14/site-packages/esgpull/context.py", line 268, in _distribute_hits
    offsets = _distribute_hits_impl(hits, offset)
  File "../python3.14/site-packages/esgpull/context.py", line 250, in _distribute_hits_impl
    accs[i] += steps[i]
    ~~~~^^^
IndexError: list index out of range
IndexError: list index out of range
```

This fix simply returns an empty list from `_distribute_hits_impl` and also catches this event early in `_distribute_hits`. This prevents the IndexError and returns an empty list silently. This eventually results in `search()` returning an empty list.