### PR TITLE
fix: update tests after CEDA deletion accident

### DIFF
--- a/tests/cli/test_dataset.py
+++ b/tests/cli/test_dataset.py
@@ -30,7 +30,7 @@ def test_update_displays_dataset_completion(root: Path, config: Config):
             "variable_id:areacella",
             "experiment_id:1pctCO2",
             "--distrib",
-            "false",
+            "true",
             "--track",
         ],
     )

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -22,7 +22,7 @@ def test_update_after_remove(root: Path, config: Config):
             "experiment_id:1pctCO2",
             "source_id:CNRM-ESM2-1",
             "--distrib",
-            "false",
+            "true",
             "--track",
         ],
     )
@@ -47,7 +47,7 @@ def test_update_after_remove(root: Path, config: Config):
             "experiment_id:1pctCO2",
             "source_id:CNRM-ESM2-1",
             "--distrib",
-            "false",
+            "true",
             "--track",
         ],
     )

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -48,7 +48,7 @@ def test_update_updates_timestamp(root: Path, config: Config):
             "variable_id:areacella",
             "experiment_id:1pctCO2",
             "--distrib",
-            "false",
+            "true",
             "--track",
         ],
     )


### PR DESCRIPTION
Switching from `--distrib false` to `--distrib true` for a subset of tests, since CEDA doesn't have those anymore. 

Tests are slightly slower as a result.