### PR TITLE
fix: skip duplicate file_ids to prevent DB constraint violations

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -590,6 +590,7 @@ class Context:
     ) -> list[File]:
         files: list[File] = []
         shas: set[str] = set()
+        file_ids: set[str] = set()
         async for result in self._fetch(*results):
             files_result = result.to(ResultFiles)
             files_result.process()
@@ -597,9 +598,13 @@ class Context:
                 for file in files_result.data:
                     if not keep_duplicates and file.sha in shas:
                         logger.debug(f"Duplicate file {file.file_id}")
-                    else:
-                        files.append(file)
-                        shas.add(file.sha)
+                        continue
+                    if not keep_duplicates and file.file_id in file_ids:
+                        logger.debug(f"Duplicate file_id {file.file_id}")
+                        continue
+                    files.append(file)
+                    shas.add(file.sha)
+                    file_ids.add(file.file_id)
         return files
 
     async def _search_as_queries(

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -431,3 +431,78 @@ def test_solr_unchanged(ctx):
     assert params["query"] == "source_id:CESM2 AND variable_id:tas"
     assert "source_id" not in params
     assert "variable_id" not in params
+
+
+def test_files_skips_duplicate_file_ids(ctx):
+    """Test that _files skips duplicate file_ids to prevent DB constraint violations."""
+    import asyncio
+    from unittest.mock import patch, MagicMock
+    from esgpull.context import ResultFiles
+
+    # Create Solr response docs that will be deserialized by File.serialize()
+    # Two files with same file_id (dataset.v1.file.nc) but different checksums
+    solr_docs = [
+        {
+            "instance_id": "dataset.v1.file.nc|node1.com",
+            "dataset_id": "dataset.v1|node1.com",
+            "title": "file.nc",
+            "url": "https://node1.com/file.nc|application/netcdf",
+            "data_node": "node1.com",
+            "checksum": "abc123",
+            "checksum_type": "SHA256",
+            "size": 1000,
+            "directory_format_template_": "%(root)s/v1",  # Simple template
+        },
+        {
+            "instance_id": "dataset.v1.file.nc|node2.com",
+            "dataset_id": "dataset.v1|node2.com",
+            "title": "file.nc",
+            "url": "https://node2.com/file.nc|application/netcdf",
+            "data_node": "node2.com",
+            "checksum": "def456",  # Different checksum!
+            "checksum_type": "SHA256",
+            "size": 1000,
+            "directory_format_template_": "%(root)s/v1",  # Simple template
+        },
+        {
+            "instance_id": "dataset.v1.other.nc|node1.com",
+            "dataset_id": "dataset.v1|node1.com",
+            "title": "other.nc",
+            "url": "https://node1.com/other.nc|application/netcdf",
+            "data_node": "node1.com",
+            "checksum": "xyz789",
+            "checksum_type": "SHA256",
+            "size": 2000,
+            "directory_format_template_": "%(root)s/v1",  # Simple template
+        },
+    ]
+
+    # Create a ResultFiles with proper JSON that will be parsed by process()
+    query = Query()
+    result = ResultFiles(query=query, file=True)
+    result.request = MagicMock()
+    result.json = {"response": {"docs": solr_docs}}
+
+    # Mock _fetch to yield our result
+    async def mock_fetch(*results):
+        yield result
+
+    async def run_test():
+        with patch.object(ctx, "_fetch", mock_fetch):
+            return await ctx._files(result, keep_duplicates=False)
+
+    result_files = asyncio.run(run_test())
+
+    # Should only have 2 files (second one with duplicate file_id is skipped)
+    assert len(result_files) == 2
+
+    # Verify the file_ids in the result
+    file_ids = {f.file_id for f in result_files}
+    assert file_ids == {"dataset.v1.file.nc", "dataset.v1.other.nc"}
+
+    # The first file with dataset.v1.file.nc should be kept (abc123 checksum)
+    duplicate_files = [
+        f for f in result_files if f.file_id == "dataset.v1.file.nc"
+    ]
+    assert len(duplicate_files) == 1
+    assert duplicate_files[0].checksum == "abc123"


### PR DESCRIPTION
When multiple replicas of the same file have different checksums, the database constraint would fail after running update. Fix is to simply skip duplicate file_ids - keeping the first one encountered.

