### PR TITLE
fix: skip a file_id already in db

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -587,10 +587,11 @@ class Context:
         self,
         *results: ResultSearch,
         keep_duplicates: bool,
+        existing_file_ids: set[str] | None = None,
     ) -> list[File]:
         files: list[File] = []
         shas: set[str] = set()
-        file_ids: set[str] = set()
+        file_ids: set[str] = existing_file_ids or set()
         async for result in self._fetch(*results):
             files_result = result.to(ResultFiles)
             files_result.process()

--- a/esgpull/models/sql.py
+++ b/esgpull/models/sql.py
@@ -110,6 +110,10 @@ class file:
         return sa.select(File.sha).where(File.file_id == file_id).limit(1)
 
     @staticmethod
+    def all_file_ids() -> sa.Select[tuple[str]]:
+        return sa.select(File.file_id)
+
+    @staticmethod
     def total_size_with_status(
         *status: FileStatus,
         query_sha: str | None = None,


### PR DESCRIPTION
Follow-up to #132 that handles the missing case: 
* a `File` in database shares `file_id` with a new one from an index_node
* the 2 `File` have different `checksum`