### PR TITLE
fix(cli.update): deduplicate on file_id instead of sha

### DIFF
--- a/esgpull/models/sql.py
+++ b/esgpull/models/sql.py
@@ -110,6 +110,10 @@ class file:
         return sa.select(File.sha).where(File.file_id == file_id).limit(1)
 
     @staticmethod
+    def all_file_ids() -> sa.Select[tuple[str]]:
+        return sa.select(File.file_id)
+
+    @staticmethod
     def total_size_with_status(
         *status: FileStatus,
         query_sha: str | None = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from esgpull.config import Config
 from esgpull.constants import CONFIG_FILENAME
+from esgpull.database import Database
 from esgpull.install_config import InstallConfig
 from esgpull.models import File, FileStatus
 from tests.utils import CEDA_NODE
@@ -50,3 +51,8 @@ def file():
     )
     f.compute_sha()
     return f
+
+
+@pytest.fixture
+def db(config):
+    return Database.from_config(config)


### PR DESCRIPTION
Follow-up to https://github.com/ESGF/esgf-download/pull/132 that handles the missing case:

* a File in database shares file_id with a new one from an index_node
* the 2 File have different checksum