### PR TITLE
feat(cli.search): better error message on probe error

### DIFF
--- a/esgpull/cli/search.py
+++ b/esgpull/cli/search.py
@@ -6,7 +6,13 @@ import click
 from click.exceptions import Abort, Exit
 
 from esgpull.cli.decorators import args, groups, opts
-from esgpull.cli.utils import filter_keys, init_esgpull, parse_query, totable
+from esgpull.cli.utils import (
+    filter_keys,
+    init_esgpull,
+    parse_query,
+    probe_and_abort,
+    totable,
+)
 from esgpull.context import IndexNode
 from esgpull.exceptions import PageIndexError
 from esgpull.graph import Graph
@@ -99,7 +105,7 @@ def search(
             esg.ui.raise_maybe_record(Exit(0))
         esg.graph.add(query, force=True)
         query = esg.graph.expand(query.sha)
-        esg.context.probe()
+        probe_and_abort(esg)
         hits = esg.context.hits(
             query,
             file=file,

--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -7,7 +7,12 @@ import click
 from click.exceptions import Abort, Exit
 
 from esgpull.cli.decorators import args, opts
-from esgpull.cli.utils import get_queries, init_esgpull, valid_name_tag
+from esgpull.cli.utils import (
+    get_queries,
+    init_esgpull,
+    probe_and_abort,
+    valid_name_tag,
+)
 from esgpull.context import HintsDict, ResultSearch
 from esgpull.exceptions import UnsetOptionsError
 from esgpull.models import Dataset, File, FileStatus, Query, sql
@@ -78,7 +83,7 @@ def update(
         if not qfs:
             esg.ui.print(":stop_sign: Trying to update untracked queries.")
             esg.ui.raise_maybe_record(Exit(0))
-        esg.context.probe()
+        probe_and_abort(esg)
         hints = esg.context.hints(
             *[qf.expanded for qf in qfs],
             file=True,

--- a/esgpull/cli/utils.py
+++ b/esgpull/cli/utils.py
@@ -7,7 +7,7 @@ from typing import Any, Literal
 
 import click
 import yaml
-from click.exceptions import BadArgumentUsage
+from click.exceptions import Abort, BadArgumentUsage
 from rich.box import MINIMAL_DOUBLE_HEAD
 from rich.table import Table
 from rich.text import Text
@@ -258,3 +258,13 @@ def extract_subdict(doc: dict, key: str | None) -> dict:
     for part in key.split(".")[::-1]:
         doc = {part: doc}
     return doc
+
+
+def probe_and_abort(esg: Esgpull) -> None:
+    try:
+        esg.context.probe()
+    except Exception as err:
+        index_node = esg.config.api.index_node
+        esg.ui.print(err.args)
+        esg.ui.print(f"[red]ERROR[/] '{index_node}' is not responding")
+        esg.ui.raise_maybe_record(Abort)


### PR DESCRIPTION
Closes https://github.com/ESGF/esgf-download/issues/140

Replaces the stack trace on `probe` error (when an index node is not responding) with a more concise error.

## Example

```shell
$ esgpull search variable_id:c2h2 -0
(
    'fetch',
    [
        HTTPStatusError("Server error '500 500' for url
'https://esgf-node.ipsl.upmc.fr/esg-search/search?type=File&offset=0&limit=0&format=application%2Fsolr%2Bjson&fields=instance_
id&distrib=true&latest=true&retracted=false'\nFor more information check:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500")
    ]
)
ERROR 'esgf-node.ipsl.upmc.fr' is not responding
Aborted!
```