### PR TITLE
Fix mypy type checks

### DIFF
--- a/esgpull/cli/plugins.py
+++ b/esgpull/cli/plugins.py
@@ -46,7 +46,7 @@ def list_plugins(verbosity: Verbosity, json_output: bool = False):
             result = {}
             for name, p in esg.plugin_manager.plugins.items():
                 # Get handlers by event type
-                handlers = {}
+                handlers: dict[str, list[dict]] = {}
                 for h in p.handlers:
                     event_type = h.event.value
                     if event_type not in handlers:
@@ -81,7 +81,7 @@ def list_plugins(verbosity: Verbosity, json_output: bool = False):
 
                 # Collect event handlers with their details
                 handler_rows = []
-                events_by_type = {}
+                events_by_type: dict[str, list[str]] = {}
                 for h in p.handlers:
                     event_type = h.event.value
                     if event_type not in events_by_type:

--- a/esgpull/cli/update.py
+++ b/esgpull/cli/update.py
@@ -159,13 +159,13 @@ def update(
         # Fetch files and update db
         # [?] TODO: dry_run to print urls here
         with esg.ui.spinner("Fetching datasets"):
-            coros = []
+            dataset_coros = []
             for qf in qfs:
-                coro = esg.context._datasets(
+                dataset_coro = esg.context._datasets(
                     *qf.dataset_results, keep_duplicates=False
                 )
-                coros.append(coro)
-            datasets = esg.context.sync_gather(*coros)
+                dataset_coros.append(dataset_coro)
+            datasets = esg.context.sync_gather(*dataset_coros)
             for qf, qf_datasets in zip(qfs, datasets):
                 qf.datasets = [
                     Dataset(
@@ -175,12 +175,12 @@ def update(
                     for record in qf_datasets
                 ]
         with esg.ui.spinner("Fetching files"):
-            coros = []
+            file_coros = []
             for qf in qfs:
-                coro = esg.context._files(*qf.results, keep_duplicates=False)
-                coros.append(coro)
-            files = esg.context.sync_gather(*coros)
-            for qf, qf_files in zip(qfs, files):
+                file_coro = esg.context._files(*qf.results, keep_duplicates=False)
+                file_coros.append(file_coro)
+            files_per_qf = esg.context.sync_gather(*file_coros)
+            for qf, qf_files in zip(qfs, files_per_qf):
                 qf.files = qf_files
         for qf in qfs:
             if not qf.query.tracked:

--- a/esgpull/cli/utils.py
+++ b/esgpull/cli/utils.py
@@ -14,7 +14,7 @@ from rich.text import Text
 
 from esgpull import Esgpull
 from esgpull.graph import Graph
-from esgpull.models import Dataset, File, Option, Options, Query, Selection
+from esgpull.models import DatasetRecord, File, Option, Options, Query, Selection
 from esgpull.tui import UI, TempUI, Verbosity, logger
 from esgpull.utils import format_size
 
@@ -74,7 +74,7 @@ class EnumParam(click.Choice):
 
 
 def filter_keys(
-    docs: Sequence[File | Dataset],
+    docs: Sequence[File | DatasetRecord],
     ids: range,
     size: bool = True,
     data_node: bool = False,

--- a/esgpull/config.py
+++ b/esgpull/config.py
@@ -248,7 +248,7 @@ config_fixers = [fix_rename_search_api, fix_remove_auth]
 class TomlKitConfigSettingsSource(TomlConfigSettingsSource):
     def _read_file(self, file_path: Path) -> dict[str, Any]:
         with open(file_path, mode="rb") as toml_file:
-            doc = tomlkit.load(toml_file)
+            doc: dict[str, Any] = tomlkit.load(toml_file)
             for fixer in config_fixers:
                 try:
                     doc = fixer(doc)

--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, TypeAlias, TypeVar
+from typing import Any, TypeAlias, TypeVar, TYPE_CHECKING
 from urllib.parse import urlparse
 
 if sys.version_info < (3, 11):
@@ -20,6 +20,9 @@ from esgpull.exceptions import SolrUnstableQueryError
 from esgpull.models import DatasetRecord, File, Query
 from esgpull.tui import logger
 from esgpull.utils import format_date_iso, sync
+
+if TYPE_CHECKING:
+    from esgpull.models import Dataset
 
 # workaround for notebooks with running event loop
 try:

--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import AsyncIterator, Callable, Coroutine, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, TypeAlias, TypeVar, TYPE_CHECKING
+from typing import Any, TypeAlias, TypeVar
 from urllib.parse import urlparse
 
 if sys.version_info < (3, 11):
@@ -20,7 +20,6 @@ from esgpull.exceptions import SolrUnstableQueryError
 from esgpull.models import DatasetRecord, File, Query
 from esgpull.tui import logger
 from esgpull.utils import format_date_iso, sync
-
 
 # workaround for notebooks with running event loop
 try:

--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -21,8 +21,6 @@ from esgpull.models import DatasetRecord, File, Query
 from esgpull.tui import logger
 from esgpull.utils import format_date_iso, sync
 
-if TYPE_CHECKING:
-    from esgpull.models import Dataset
 
 # workaround for notebooks with running event loop
 try:
@@ -795,8 +793,8 @@ class Context:
         date_from: datetime | None = None,
         date_to: datetime | None = None,
         keep_duplicates: bool = True,
-    ) -> Sequence[File | Dataset]:
-        fun: Callable[..., Sequence[File | Dataset]]
+    ) -> Sequence[File | DatasetRecord]:
+        fun: Callable[..., Sequence[File | DatasetRecord]]
         if file:
             fun = self.files
         else:

--- a/esgpull/database.py
+++ b/esgpull/database.py
@@ -4,11 +4,15 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-from typing import TypeVar
+from typing import TypeVar, TYPE_CHECKING
 
 import alembic.command
 import sqlalchemy as sa
 import sqlalchemy.orm
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Mapper
+
 from alembic.config import Config as AlembicConfig
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
@@ -162,7 +166,7 @@ class Database:
             return False
 
     def __contains__(self, item: Base | BaseNoSHA) -> bool:
-        mapper = inspect(item.__class__)
+        mapper: Mapper = inspect(item.__class__)
         pk_col = mapper.primary_key[0]
         pk_value = getattr(item, pk_col.name)
         stmt = sa.exists().where(pk_col == pk_value)

--- a/esgpull/esgpull.py
+++ b/esgpull/esgpull.py
@@ -126,7 +126,7 @@ class Esgpull:
         plugin_config_path = self.config.paths.plugins / "plugins.toml"
         try:
             self.plugin_manager = get_plugin_manager()
-            self.plugin_manager.__init__(config_path=plugin_config_path)
+            PluginManager.__init__(self.plugin_manager, config_path=plugin_config_path)
         except ValueError:
             self.plugin_manager = PluginManager(config_path=plugin_config_path)
             set_plugin_manager(self.plugin_manager)

--- a/esgpull/models/base.py
+++ b/esgpull/models/base.py
@@ -19,7 +19,7 @@ Sha = sa.String(40)
 # Base class for all models - provides core SQLAlchemy functionality
 class _BaseModel(MappedAsDataclass, DeclarativeBase):
     __dataclass_fields__: ClassVar[dict[str, Field]]
-    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__") # type: ignore
+    __sql_attrs__: ClassVar[tuple[str, ...]] = ("id", "_sa_instance_state", "__dataclass_fields__")
 
     @property
     def _names(self) -> tuple[str, ...]:
@@ -41,7 +41,7 @@ class _BaseModel(MappedAsDataclass, DeclarativeBase):
 # Base class for models that use SHA as primary key
 class Base(_BaseModel):
     __abstract__ = True
-    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__") # type: ignore
+    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__")
 
     sha: Mapped[str] = mapped_column(
         Sha,

--- a/esgpull/models/base.py
+++ b/esgpull/models/base.py
@@ -19,7 +19,7 @@ Sha = sa.String(40)
 # Base class for all models - provides core SQLAlchemy functionality
 class _BaseModel(MappedAsDataclass, DeclarativeBase):
     __dataclass_fields__: ClassVar[dict[str, Field]]
-    __sql_attrs__: ClassVar[tuple[str, ...]] = ("id", "_sa_instance_state", "__dataclass_fields__")
+    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__")  # type: ignore
 
     @property
     def _names(self) -> tuple[str, ...]:
@@ -41,7 +41,7 @@ class _BaseModel(MappedAsDataclass, DeclarativeBase):
 # Base class for models that use SHA as primary key
 class Base(_BaseModel):
     __abstract__ = True
-    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__")
+    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__")  # type: ignore
 
     sha: Mapped[str] = mapped_column(
         Sha,
@@ -60,7 +60,7 @@ class Base(_BaseModel):
 # Base class for models that don't use SHA (e.g., Dataset)
 class BaseNoSHA(_BaseModel):
     __abstract__ = True
-    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__")
+    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__")  # type: ignore
 
 
 # Keep SHAKeyMixin for backward compatibility if needed

--- a/esgpull/models/base.py
+++ b/esgpull/models/base.py
@@ -19,7 +19,7 @@ Sha = sa.String(40)
 # Base class for all models - provides core SQLAlchemy functionality
 class _BaseModel(MappedAsDataclass, DeclarativeBase):
     __dataclass_fields__: ClassVar[dict[str, Field]]
-    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__")
+    __sql_attrs__ = ("id", "_sa_instance_state", "__dataclass_fields__") # type: ignore
 
     @property
     def _names(self) -> tuple[str, ...]:
@@ -41,7 +41,7 @@ class _BaseModel(MappedAsDataclass, DeclarativeBase):
 # Base class for models that use SHA as primary key
 class Base(_BaseModel):
     __abstract__ = True
-    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__")
+    __sql_attrs__ = ("id", "sha", "_sa_instance_state", "__dataclass_fields__") # type: ignore
 
     sha: Mapped[str] = mapped_column(
         Sha,

--- a/esgpull/models/dataset.py
+++ b/esgpull/models/dataset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -23,6 +23,9 @@ class DatasetRecord:
     data_node: str
     size: int
     number_of_files: int
+
+    def asdict(self) -> Mapping[str, Any]:
+        return asdict(self)
 
     @classmethod
     def serialize(cls, source: dict) -> DatasetRecord:

--- a/esgpull/models/options.py
+++ b/esgpull/models/options.py
@@ -97,7 +97,7 @@ class Options(Base):
         name: str,
         value: Option | str | bool | None,
     ) -> None:
-        if name in self.__sql_attrs__:
+        if name in self.__sql_attrs__:   # type: ignore[has-type]
             super().__setattr__(name, value)
         elif name in self._names:
             super().__setattr__(name, Option(value))

--- a/esgpull/models/query.py
+++ b/esgpull/models/query.py
@@ -115,7 +115,7 @@ class File(Base):
             size=source["size"],
         )
         if "status" in source:
-            result.status = FileStatus(source.get("status").lower())
+            result.status = FileStatus(source["status"].lower())
         return result
 
     @classmethod

--- a/esgpull/plugin.py
+++ b/esgpull/plugin.py
@@ -151,7 +151,7 @@ class PluginConfig:
     enabled: set[str] = field(default_factory=set)
     disabled: set[str] = field(default_factory=set)
     plugins: dict[str, dict[str, Any]] = field(default_factory=dict)
-    _raw: tomlkit.TOMLDocument = field(default_factory=tomlkit.TOMLDocument)
+    _raw: dict = field(default_factory=dict)
 
     def __post_init__(self):
         if "plugins" not in self._raw:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,4 +113,6 @@ dev = [
     "pytest-cov>=6.1.1",
     "pytest-mypy>=1.0.1",
     "pytest-xdist>=3.6.1",
+    "types-aiofiles>=25.1.0.20251011",
+    "types-pyyaml>=6.0.12.20250915",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ minversion = "6.2.4"
 filterwarnings = ["ignore::DeprecationWarning"]
 markers = ["slow: mark test as slow to run"]
 addopts = "-r aR -n auto --cov=esgpull --cov-config=pyproject.toml --cov-report term-missing:skip-covered --mypy"
-testpaths = ["tests/"]
+testpaths = ["tests/", "esgpull/"]
 
 [tool.ruff]
 line-length = 79

--- a/uv.lock
+++ b/uv.lock
@@ -411,6 +411,8 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mypy" },
     { name = "pytest-xdist" },
+    { name = "types-aiofiles" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -444,6 +446,8 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-mypy", specifier = ">=1.0.1" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
+    { name = "types-aiofiles", specifier = ">=25.1.0.20251011" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -1532,6 +1536,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-aiofiles"
+version = "25.1.0.20251011"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6c/6d23908a8217e36704aa9c79d99a620f2fdd388b66a4b7f72fbc6b6ff6c6/types_aiofiles-25.1.0.20251011.tar.gz", hash = "sha256:1c2b8ab260cb3cd40c15f9d10efdc05a6e1e6b02899304d80dfa0410e028d3ff", size = 14535, upload-time = "2025-10-11T02:44:51.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/0f/76917bab27e270bb6c32addd5968d69e558e5b6f7fb4ac4cbfa282996a96/types_aiofiles-25.1.0.20251011-py3-none-any.whl", hash = "sha256:8ff8de7f9d42739d8f0dadcceeb781ce27cd8d8c4152d4a7c52f6b20edb8149c", size = 14338, upload-time = "2025-10-11T02:44:50.054Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Purpose
This project includes type annotations. However, `pytest-mypy` only inspects files specified in the pytest `testpaths` configuration (per pyproject.toml). (see [discussion](https://github.com/realpython/pytest-mypy/issues/70)) This caused mypy to skip project code when run in CI (it was only linting test files).

If run directly (`mypy esgpull/`, `pytest .`, etc), ~30 type errors were returned.

This PR fixes mypy to run when intended, and produces clean error output.

## Summary of changes
This PR has been broken down into conceptually related commits, and in cases where errors are ignored, commit messages link directly to underlying rationale.

AFAICT, the correct return type for search functions is `DatasetRecord` rather than `Dataset`, and this annotation does seem to resolve many of the warnings. Let me know if that is incorrect.

As this is my first PR to this repo, I'm happy to revise on request. I like to have a clean slate for tests before I start larger edits :)