### PR TITLE
fix: bridge connection error

### DIFF
--- a/esgpull/context.py
+++ b/esgpull/context.py
@@ -510,6 +510,13 @@ class Context:
     async def _fetch_one(self, result: RT) -> RT:
         host = result.request.url.host
         semaphore = self.get_or_create_semaphore(host)
+
+        # The bridge API tends to produce non-standard errors when too many
+        # new connections open in a short time span. With no sleep, the 4th
+        # connection is always where it breaks. 50ms sleep seems to fix that.
+        if self.client is None:
+            await asyncio.sleep(0.005)
+
         client = self.get_or_create_client()
         async with semaphore:
             logger.debug(f"GET {host} params={result.request.url.params}")

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -3,7 +3,12 @@ from time import perf_counter
 
 import pytest
 
-from esgpull.context import Context, IndexNode, _distribute_hits_impl
+from esgpull.context import (
+    Context,
+    IndexNode,
+    _distribute_hits_impl,
+    ResultSearch,
+)
 from esgpull.models import Query
 from tests.utils import CEDA_NODE, DRKZ_NODE, IPSL_NODE, ORNL_BRIDGE
 
@@ -573,3 +578,33 @@ def test_update_checks_files_by_file_id_not_sha(db):
     assert file_from_db is not None
     assert file_from_db.file_id == "dataset.v1.test.nc"
     assert file_from_db.checksum == "original_checksum_abc123"
+
+
+async def simple_fetch(ctx: Context, prepared: ResultSearch) -> ResultSearch:
+    async for result in ctx._fetch(prepared):
+        return result
+    assert False
+
+
+def test_bridge_client_connection(ctx: Context):
+    # query as seen in issue #148
+    query = Query(
+        selection={
+            "project": "CMIP6",
+            "activity_id": "HighResMIP",
+            "variable_id": "areacello",
+        }
+    )
+    file_hits = ctx.hits(query, file=True)
+    assert len(file_hits) > 0
+    assert file_hits[0] > 0
+    dataset_hits = ctx.hits(query, file=False)
+    assert len(dataset_hits) > 0
+    assert dataset_hits[0] > 0
+    file_prepared = ctx.prepare_search(query, file=True, hits=file_hits)
+    dataset_prepared = ctx.prepare_search(query, file=False, hits=dataset_hits)
+    file_result = ctx._sync(simple_fetch(ctx, file_prepared[0]))
+    dataset_result = ctx._sync(simple_fetch(ctx, dataset_prepared[0]))
+    assert file_result.exc is None
+    assert dataset_result.exc is None
+    # project:CMIP6 activity_id:HighResMIP variable_id:areacello --distrib true


### PR DESCRIPTION
Resolves https://github.com/ESGF/esgf-download/issues/148

Sleep 50ms before creating a new `httpx.AsyncClient`, this should not impact performance of esgpull, the sleep is order of magnitudes shorter than the time spent in any command (especially update which is where the issue occurs)

The error was happening in 100% of my tests yesterday (2025-05-06) but it does not happen anymore (on main, without these changes) the next day. We will probably merge this PR to mitigate potential future errors anyway.